### PR TITLE
Fix rustc, clippy warnings

### DIFF
--- a/src/examples/test_rectangle_rotated.rs
+++ b/src/examples/test_rectangle_rotated.rs
@@ -9,7 +9,7 @@ mod tests {
             angle_between_points::AngleBetweenPoints,
             distance::euclidian_distance_between_points::EuclidianDistanceBetweenPoints,
             fix_point::FixPoint,
-            lines::{parallel_lines::ParallelLines, perpendicular_lines::PerpendicularLines},
+            lines::perpendicular_lines::PerpendicularLines,
         },
         primitives::{line::Line, point2::Point2},
         sketch::Sketch,

--- a/src/primitives/arc.rs
+++ b/src/primitives/arc.rs
@@ -22,11 +22,11 @@ impl Arc {
         end_angle: f64,
     ) -> Self {
         Self {
-            center: center,
+            center,
             data: SVector::<f64, 3>::from_row_slice(&[radius, start_angle, end_angle]),
             gradient: SVector::<f64, 3>::zeros(),
 
-            clockwise: clockwise,
+            clockwise,
         }
     }
 

--- a/src/primitives/circle.rs
+++ b/src/primitives/circle.rs
@@ -13,7 +13,7 @@ pub struct Circle {
 impl Circle {
     pub fn new(center: Rc<RefCell<Point2>>, radius: f64) -> Self {
         Self {
-            center: center,
+            center,
             data: SVector::<f64, 1>::from_row_slice(&[radius]),
             gradient: SVector::<f64, 1>::zeros(),
         }

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -2,6 +2,7 @@ use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
 use super::{constraints::Constraint, primitives::Parametric};
 
+#[derive(Default)]
 pub struct Sketch {
     primitives: VecDeque<Rc<RefCell<dyn Parametric>>>,
     constraints: VecDeque<Rc<RefCell<dyn Constraint>>>,
@@ -9,10 +10,7 @@ pub struct Sketch {
 
 impl Sketch {
     pub fn new() -> Self {
-        Self {
-            primitives: VecDeque::new(),
-            constraints: VecDeque::new(),
-        }
+        Self::default()
     }
 
     pub fn add_primitive(&mut self, primitive: Rc<RefCell<dyn Parametric>>) {


### PR DESCRIPTION
Remove an unused import, use field init shorthand, implement `Default` for `Sketch`.

I had to disable format-on-save locally because I didn't want to increase the diff a bunch, and the files aren't formatted per default `rustfmt` rules. Are you using some other formatter or is all the formatting manual?