### PR TITLE
Used enum instead of dyn trait

### DIFF
--- a/src/constraints/angle_between_points.rs
+++ b/src/constraints/angle_between_points.rs
@@ -5,7 +5,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use crate::{constraints::Constraint, primitives::point2::Point2};
+use crate::{
+    constraints::Constraint,
+    primitives::{point2::Point2, ParametricCell},
+};
 
 // This is a sketch constraint that makes the end point of an arc coincident with a point.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -84,11 +87,11 @@ impl AngleBetweenPoints {
 }
 
 impl Constraint for AngleBetweenPoints {
-    fn references(&self) -> Vec<Rc<RefCell<dyn crate::primitives::Parametric>>> {
+    fn references(&self) -> Vec<ParametricCell> {
         vec![
-            self.point1.clone(),
-            self.point2.clone(),
-            self.middle_point.clone(),
+            ParametricCell::Point2(self.point1.clone()),
+            ParametricCell::Point2(self.point2.clone()),
+            ParametricCell::Point2(self.middle_point.clone()),
         ]
     }
 
@@ -189,15 +192,15 @@ mod tests {
         let point_middle = Rc::new(RefCell::new(Point2::new(0.0, 0.0)));
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_a.clone()))
+            .add_primitive(ParametricCell::Point2(point_a.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_b.clone()))
+            .add_primitive(ParametricCell::Point2(point_b.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_middle.clone()))
+            .add_primitive(ParametricCell::Point2(point_middle.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(AngleBetweenPoints::new(

--- a/src/constraints/coincident/arc_end_point_coincident.rs
+++ b/src/constraints/coincident/arc_end_point_coincident.rs
@@ -8,7 +8,7 @@ use tsify::Tsify;
 
 use crate::{
     constraints::Constraint,
-    primitives::{arc::Arc, point2::Point2},
+    primitives::{arc::Arc, point2::Point2, ParametricCell},
 };
 
 // This is a sketch constraint that makes the end point of an arc coincident with a point.
@@ -43,8 +43,11 @@ impl ArcEndPointCoincident {
 }
 
 impl Constraint for ArcEndPointCoincident {
-    fn references(&self) -> Vec<Rc<RefCell<dyn crate::primitives::Parametric>>> {
-        vec![self.arc.clone(), self.point.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![
+            ParametricCell::Arc(self.arc.clone()),
+            ParametricCell::Point2(self.point.clone()),
+        ]
     }
 
     fn loss_value(&self) -> f64 {
@@ -113,23 +116,23 @@ mod tests {
         )));
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(center.clone()))
+            .add_primitive(ParametricCell::Point2(center.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(arc1.clone()))
+            .add_primitive(ParametricCell::Arc(arc1.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2_start.clone()))
+            .add_primitive(ParametricCell::Point2(line2_start.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2_end.clone()))
+            .add_primitive(ParametricCell::Point2(line2_end.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2.clone()))
+            .add_primitive(ParametricCell::Line(line2.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(ArcEndPointCoincident::new(

--- a/src/constraints/coincident/arc_start_point_coincident.rs
+++ b/src/constraints/coincident/arc_start_point_coincident.rs
@@ -8,7 +8,7 @@ use tsify::Tsify;
 
 use crate::{
     constraints::Constraint,
-    primitives::{arc::Arc, point2::Point2},
+    primitives::{arc::Arc, point2::Point2, ParametricCell},
 };
 
 // This is a sketch constraint that makes the start point of an arc coincident with a point.
@@ -43,8 +43,11 @@ impl ArcStartPointCoincident {
 }
 
 impl Constraint for ArcStartPointCoincident {
-    fn references(&self) -> Vec<Rc<RefCell<dyn crate::primitives::Parametric>>> {
-        vec![self.arc.clone(), self.point.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![
+            ParametricCell::Arc(self.arc.clone()),
+            ParametricCell::Point2(self.point.clone()),
+        ]
     }
 
     fn loss_value(&self) -> f64 {
@@ -113,23 +116,23 @@ mod tests {
         )));
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(center.clone()))
+            .add_primitive(ParametricCell::Point2(center.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(arc1.clone()))
+            .add_primitive(ParametricCell::Arc(arc1.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2_start.clone()))
+            .add_primitive(ParametricCell::Point2(line2_start.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2_end.clone()))
+            .add_primitive(ParametricCell::Point2(line2_end.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2.clone()))
+            .add_primitive(ParametricCell::Line(line2.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(ArcStartPointCoincident::new(

--- a/src/constraints/distance/euclidian_distance_between_points.rs
+++ b/src/constraints/distance/euclidian_distance_between_points.rs
@@ -5,7 +5,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use crate::{constraints::Constraint, primitives::point2::Point2};
+use crate::{
+    constraints::Constraint,
+    primitives::{point2::Point2, ParametricCell},
+};
 
 // This is a sketch constraint that makes the end point of an arc coincident with a point.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -65,8 +68,11 @@ impl EuclidianDistanceBetweenPoints {
 }
 
 impl Constraint for EuclidianDistanceBetweenPoints {
-    fn references(&self) -> Vec<Rc<RefCell<dyn crate::primitives::Parametric>>> {
-        vec![self.point1.clone(), self.point2.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![
+            ParametricCell::Point2(self.point1.clone()),
+            ParametricCell::Point2(self.point2.clone()),
+        ]
     }
 
     fn loss_value(&self) -> f64 {
@@ -133,11 +139,11 @@ mod tests {
         let point_b = Rc::new(RefCell::new(Point2::new(0.0, 1.0)));
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_a.clone()))
+            .add_primitive(ParametricCell::Point2(point_a.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_b.clone()))
+            .add_primitive(ParametricCell::Point2(point_b.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(EuclidianDistanceBetweenPoints::new(

--- a/src/constraints/distance/horizontal_distance_between_points.rs
+++ b/src/constraints/distance/horizontal_distance_between_points.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use crate::{constraints::Constraint, primitives::point2::Point2};
+use crate::{
+    constraints::Constraint,
+    primitives::{point2::Point2, ParametricCell},
+};
 
 // This is a sketch constraint that makes the end point of an arc coincident with a point.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -65,8 +68,11 @@ impl HorizontalDistanceBetweenPoints {
 }
 
 impl Constraint for HorizontalDistanceBetweenPoints {
-    fn references(&self) -> Vec<Rc<RefCell<dyn crate::primitives::Parametric>>> {
-        vec![self.point1.clone(), self.point2.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![
+            ParametricCell::Point2(self.point1.clone()),
+            ParametricCell::Point2(self.point2.clone()),
+        ]
     }
 
     fn loss_value(&self) -> f64 {
@@ -133,11 +139,11 @@ mod tests {
         let point_b = Rc::new(RefCell::new(Point2::new(0.0, 1.0)));
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_a.clone()))
+            .add_primitive(ParametricCell::Point2(point_a.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_b.clone()))
+            .add_primitive(ParametricCell::Point2(point_b.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(HorizontalDistanceBetweenPoints::new(

--- a/src/constraints/distance/vertical_distance_between_points.rs
+++ b/src/constraints/distance/vertical_distance_between_points.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use crate::{constraints::Constraint, primitives::point2::Point2};
+use crate::{
+    constraints::Constraint,
+    primitives::{point2::Point2, ParametricCell},
+};
 
 // This is a sketch constraint that makes the end point of an arc coincident with a point.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -65,8 +68,11 @@ impl VerticalDistanceBetweenPoints {
 }
 
 impl Constraint for VerticalDistanceBetweenPoints {
-    fn references(&self) -> Vec<Rc<RefCell<dyn crate::primitives::Parametric>>> {
-        vec![self.point1.clone(), self.point2.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![
+            ParametricCell::Point2(self.point1.clone()),
+            ParametricCell::Point2(self.point2.clone()),
+        ]
     }
 
     fn loss_value(&self) -> f64 {
@@ -133,11 +139,11 @@ mod tests {
         let point_b = Rc::new(RefCell::new(Point2::new(0.0, 1.0)));
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_a.clone()))
+            .add_primitive(ParametricCell::Point2(point_a.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_b.clone()))
+            .add_primitive(ParametricCell::Point2(point_b.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(VerticalDistanceBetweenPoints::new(

--- a/src/constraints/fix_point.rs
+++ b/src/constraints/fix_point.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use crate::{constraints::Constraint, primitives::point2::Point2};
+use crate::{
+    constraints::Constraint,
+    primitives::{point2::Point2, ParametricCell},
+};
 
 // This is a sketch constraint that makes the end point of an arc coincident with a point.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -41,8 +44,8 @@ impl FixPoint {
 }
 
 impl Constraint for FixPoint {
-    fn references(&self) -> Vec<Rc<RefCell<dyn crate::primitives::Parametric>>> {
-        vec![self.point.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![ParametricCell::Point2(self.point.clone())]
     }
 
     fn loss_value(&self) -> f64 {
@@ -85,7 +88,7 @@ mod tests {
         let point = Rc::new(RefCell::new(Point2::new(1.0, 0.0)));
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point.clone()))
+            .add_primitive(ParametricCell::Point2(point.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(FixPoint::new(

--- a/src/constraints/lines/equal_length.rs
+++ b/src/constraints/lines/equal_length.rs
@@ -5,7 +5,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use crate::{constraints::Constraint, primitives::line::Line};
+use crate::{
+    constraints::Constraint,
+    primitives::{line::Line, ParametricCell},
+};
 
 // This is a sketch constraint that makes the end point of an arc coincident with a point.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -39,8 +42,11 @@ impl EqualLength {
 }
 
 impl Constraint for EqualLength {
-    fn references(&self) -> Vec<Rc<RefCell<dyn crate::primitives::Parametric>>> {
-        vec![self.line1.clone(), self.line2.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![
+            ParametricCell::Line(self.line1.clone()),
+            ParametricCell::Line(self.line2.clone()),
+        ]
     }
 
     fn loss_value(&self) -> f64 {
@@ -115,15 +121,15 @@ mod tests {
         )));
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line1_start.clone()))
+            .add_primitive(ParametricCell::Point2(line1_start.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line1_end.clone()))
+            .add_primitive(ParametricCell::Point2(line1_end.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line1.clone()))
+            .add_primitive(ParametricCell::Line(line1.clone()))
             .unwrap();
 
         let line2_start = Rc::new(RefCell::new(Point2::new(0.0, 4.0)));
@@ -135,15 +141,15 @@ mod tests {
 
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2_start.clone()))
+            .add_primitive(ParametricCell::Point2(line2_start.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2_end.clone()))
+            .add_primitive(ParametricCell::Point2(line2_end.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2.clone()))
+            .add_primitive(ParametricCell::Line(line2.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(EqualLength::new(line1.clone(), line2.clone())));

--- a/src/constraints/lines/horizontal_line.rs
+++ b/src/constraints/lines/horizontal_line.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use crate::{constraints::Constraint, primitives::line::Line};
+use crate::{
+    constraints::Constraint,
+    primitives::{line::Line, ParametricCell},
+};
 
 // This is a sketch constraint that makes the end point of an arc coincident with a point.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -31,8 +34,8 @@ impl HorizontalLine {
 }
 
 impl Constraint for HorizontalLine {
-    fn references(&self) -> Vec<Rc<RefCell<dyn crate::primitives::Parametric>>> {
-        vec![self.line.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![ParametricCell::Line(self.line.clone())]
     }
 
     fn loss_value(&self) -> f64 {
@@ -89,15 +92,15 @@ mod tests {
         )));
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line_start.clone()))
+            .add_primitive(ParametricCell::Point2(line_start.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line_end.clone()))
+            .add_primitive(ParametricCell::Point2(line_end.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line.clone()))
+            .add_primitive(ParametricCell::Line(line.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(HorizontalLine::new(line.clone())));

--- a/src/constraints/lines/parallel_lines.rs
+++ b/src/constraints/lines/parallel_lines.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use crate::{constraints::Constraint, primitives::line::Line};
+use crate::{
+    constraints::Constraint,
+    primitives::{line::Line, ParametricCell},
+};
 
 // This is a sketch constraint that makes the end point of an arc coincident with a point.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -40,8 +43,11 @@ impl ParallelLines {
 }
 
 impl Constraint for ParallelLines {
-    fn references(&self) -> Vec<Rc<RefCell<dyn crate::primitives::Parametric>>> {
-        vec![self.line1.clone(), self.line2.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![
+            ParametricCell::Line(self.line1.clone()),
+            ParametricCell::Line(self.line2.clone()),
+        ]
     }
 
     fn loss_value(&self) -> f64 {
@@ -143,15 +149,15 @@ mod tests {
         )));
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line1_start.clone()))
+            .add_primitive(ParametricCell::Point2(line1_start.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line1_end.clone()))
+            .add_primitive(ParametricCell::Point2(line1_end.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line1.clone()))
+            .add_primitive(ParametricCell::Line(line1.clone()))
             .unwrap();
 
         let line2_start = Rc::new(RefCell::new(Point2::new(0.0, 4.0)));
@@ -163,15 +169,15 @@ mod tests {
 
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2_start.clone()))
+            .add_primitive(ParametricCell::Point2(line2_start.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2_end.clone()))
+            .add_primitive(ParametricCell::Point2(line2_end.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2.clone()))
+            .add_primitive(ParametricCell::Line(line2.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(ParallelLines::new(

--- a/src/constraints/lines/perpendicular_lines.rs
+++ b/src/constraints/lines/perpendicular_lines.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use crate::{constraints::Constraint, primitives::line::Line};
+use crate::{
+    constraints::Constraint,
+    primitives::{line::Line, ParametricCell},
+};
 
 // This is a sketch constraint that makes the end point of an arc coincident with a point.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -40,8 +43,11 @@ impl PerpendicularLines {
 }
 
 impl Constraint for PerpendicularLines {
-    fn references(&self) -> Vec<Rc<RefCell<dyn crate::primitives::Parametric>>> {
-        vec![self.line1.clone(), self.line2.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![
+            ParametricCell::Line(self.line1.clone()),
+            ParametricCell::Line(self.line2.clone()),
+        ]
     }
 
     fn loss_value(&self) -> f64 {
@@ -151,15 +157,15 @@ mod tests {
         )));
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line1_start.clone()))
+            .add_primitive(ParametricCell::Point2(line1_start.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line1_end.clone()))
+            .add_primitive(ParametricCell::Point2(line1_end.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line1.clone()))
+            .add_primitive(ParametricCell::Line(line1.clone()))
             .unwrap();
 
         let line2_start = Rc::new(RefCell::new(Point2::new(0.0, 4.0)));
@@ -171,15 +177,15 @@ mod tests {
 
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2_start.clone()))
+            .add_primitive(ParametricCell::Point2(line2_start.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2_end.clone()))
+            .add_primitive(ParametricCell::Point2(line2_end.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line2.clone()))
+            .add_primitive(ParametricCell::Line(line2.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(PerpendicularLines::new(

--- a/src/constraints/lines/vertical_line.rs
+++ b/src/constraints/lines/vertical_line.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use crate::{constraints::Constraint, primitives::line::Line};
+use crate::{
+    constraints::Constraint,
+    primitives::{line::Line, ParametricCell},
+};
 
 // This is a sketch constraint that makes the end point of an arc coincident with a point.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -31,8 +34,8 @@ impl VerticalLine {
 }
 
 impl Constraint for VerticalLine {
-    fn references(&self) -> Vec<Rc<RefCell<dyn crate::primitives::Parametric>>> {
-        vec![self.line.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![ParametricCell::Line(self.line.clone())]
     }
 
     fn loss_value(&self) -> f64 {
@@ -89,15 +92,15 @@ mod tests {
         )));
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line_start.clone()))
+            .add_primitive(ParametricCell::Point2(line_start.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line_end.clone()))
+            .add_primitive(ParametricCell::Point2(line_end.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line.clone()))
+            .add_primitive(ParametricCell::Line(line.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(VerticalLine::new(line.clone())));

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use crate::primitives::Parametric;
+use crate::primitives::ParametricCell;
 
 pub mod angle_between_points;
 pub mod coincident;
@@ -16,7 +16,7 @@ pub mod fix_point;
 pub mod lines;
 
 pub trait Constraint: Debug {
-    fn references(&self) -> Vec<Rc<RefCell<dyn Parametric>>>;
+    fn references(&self) -> Vec<ParametricCell>;
     fn loss_value(&self) -> f64;
     fn update_gradient(&mut self);
     fn get_type(&self) -> ConstraintType;

--- a/src/examples/test_rectangle_axis_aligned.rs
+++ b/src/examples/test_rectangle_axis_aligned.rs
@@ -30,19 +30,19 @@ mod tests {
 
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_a.clone()))
+            .add_primitive(ParametricCell::Point2(point_a.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_b.clone()))
+            .add_primitive(ParametricCell::Point2(point_b.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_c.clone()))
+            .add_primitive(ParametricCell::Point2(point_c.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_d.clone()))
+            .add_primitive(ParametricCell::Point2(point_d.clone()))
             .unwrap();
 
         let line_a = Rc::new(RefCell::new(Line::new(point_a.clone(), point_b.clone())));
@@ -52,19 +52,19 @@ mod tests {
 
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line_a.clone()))
+            .add_primitive(ParametricCell::Line(line_a.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line_b.clone()))
+            .add_primitive(ParametricCell::Line(line_b.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line_c.clone()))
+            .add_primitive(ParametricCell::Line(line_c.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line_d.clone()))
+            .add_primitive(ParametricCell::Line(line_d.clone()))
             .unwrap();
 
         // Fix point a to origin

--- a/src/examples/test_rectangle_rotated.rs
+++ b/src/examples/test_rectangle_rotated.rs
@@ -35,23 +35,23 @@ impl RotatedRectangleDemo {
 
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_a.clone()))
+            .add_primitive(ParametricCell::Point2(point_a.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_b.clone()))
+            .add_primitive(ParametricCell::Point2(point_b.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_c.clone()))
+            .add_primitive(ParametricCell::Point2(point_c.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_d.clone()))
+            .add_primitive(ParametricCell::Point2(point_d.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(point_reference.clone()))
+            .add_primitive(ParametricCell::Point2(point_reference.clone()))
             .unwrap();
 
         let line_a = Rc::new(RefCell::new(Line::new(point_a.clone(), point_b.clone())));
@@ -61,19 +61,19 @@ impl RotatedRectangleDemo {
 
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line_a.clone()))
+            .add_primitive(ParametricCell::Line(line_a.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line_b.clone()))
+            .add_primitive(ParametricCell::Line(line_b.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line_c.clone()))
+            .add_primitive(ParametricCell::Line(line_c.clone()))
             .unwrap();
         sketch
             .borrow_mut()
-            .add_primitive(ParametricCell(line_d.clone()))
+            .add_primitive(ParametricCell::Line(line_d.clone()))
             .unwrap();
 
         // Fix point a to origin

--- a/src/primitives/arc.rs
+++ b/src/primitives/arc.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use super::{point2::Point2, Parametric};
+use super::{point2::Point2, Parametric, ParametricCell};
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "tsify", derive(Tsify))]
@@ -169,8 +169,8 @@ impl Arc {
 }
 
 impl Parametric for Arc {
-    fn references(&self) -> Vec<Rc<RefCell<dyn Parametric>>> {
-        vec![self.center.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![ParametricCell::Point2(self.center.clone())]
     }
 
     fn zero_gradient(&mut self) {

--- a/src/primitives/circle.rs
+++ b/src/primitives/circle.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use super::{point2::Point2, Parametric};
+use super::{point2::Point2, Parametric, ParametricCell};
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "tsify", derive(Tsify))]
@@ -62,8 +62,8 @@ impl Circle {
 }
 
 impl Parametric for Circle {
-    fn references(&self) -> Vec<Rc<RefCell<dyn Parametric>>> {
-        vec![self.center.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![ParametricCell::Point2(self.center.clone())]
     }
 
     fn zero_gradient(&mut self) {

--- a/src/primitives/line.rs
+++ b/src/primitives/line.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 
 use super::point2::Point2;
-use super::Parametric;
+use super::{Parametric, ParametricCell};
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "tsify", derive(Tsify))]
@@ -60,8 +60,11 @@ impl Line {
 }
 
 impl Parametric for Line {
-    fn references(&self) -> Vec<Rc<RefCell<dyn Parametric>>> {
-        vec![self.start.clone(), self.end.clone()]
+    fn references(&self) -> Vec<ParametricCell> {
+        vec![
+            ParametricCell::Point2(self.start.clone()),
+            ParametricCell::Point2(self.end.clone()),
+        ]
     }
 
     fn zero_gradient(&mut self) {

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,9 +1,9 @@
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell, RefMut};
 use std::fmt::Debug;
 use std::rc::Rc;
 
 use nalgebra::{DVector, DVectorView};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
@@ -15,7 +15,7 @@ pub mod point2;
 
 // A trait that defines a parametric object, meaning a SketchPrimitive that can be defined by a fixed number of parameters that can be used for gradient descent.
 pub trait Parametric: Debug {
-    fn references(&self) -> Vec<Rc<RefCell<dyn Parametric>>>;
+    fn references(&self) -> Vec<ParametricCell>;
     fn zero_gradient(&mut self);
     fn get_data(&self) -> DVector<f64>;
     fn set_data(&mut self, data: DVectorView<f64>);
@@ -34,7 +34,7 @@ pub enum Primitive {
 }
 
 impl Parametric for Primitive {
-    fn references(&self) -> Vec<Rc<RefCell<dyn Parametric>>> {
+    fn references(&self) -> Vec<ParametricCell> {
         match self {
             Primitive::Point2(p) => p.references(),
             Primitive::Line(l) => l.references(),
@@ -84,46 +84,110 @@ impl Parametric for Primitive {
     }
 }
 
-#[repr(transparent)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "tsify", derive(Tsify))]
 #[cfg_attr(feature = "tsify", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct ParametricCell(pub Rc<RefCell<dyn Parametric>>);
+pub enum ParametricCell {
+    Point2(Rc<RefCell<point2::Point2>>),
+    Line(Rc<RefCell<line::Line>>),
+    Arc(Rc<RefCell<arc::Arc>>),
+    Circle(Rc<RefCell<circle::Circle>>),
+}
 
-impl Into<Primitive> for ParametricCell {
-    fn into(self) -> Primitive {
-        self.0.borrow().to_primitive()
+impl ParametricCell {
+    pub fn borrow(&self) -> Ref<dyn Parametric> {
+        match self {
+            ParametricCell::Point2(p) => p.borrow(),
+            ParametricCell::Line(l) => l.borrow(),
+            ParametricCell::Arc(a) => a.borrow(),
+            ParametricCell::Circle(c) => c.borrow(),
+        }
+    }
+
+    pub fn borrow_mut(&self) -> RefMut<dyn Parametric> {
+        match self {
+            ParametricCell::Point2(p) => p.borrow_mut(),
+            ParametricCell::Line(l) => l.borrow_mut(),
+            ParametricCell::Arc(a) => a.borrow_mut(),
+            ParametricCell::Circle(c) => c.borrow_mut(),
+        }
+    }
+
+    pub fn ptr_eq(&self, other: &ParametricCell) -> bool {
+        match (self, other) {
+            (ParametricCell::Point2(p1), ParametricCell::Point2(p2)) => Rc::ptr_eq(p1, p2),
+            (ParametricCell::Line(l1), ParametricCell::Line(l2)) => Rc::ptr_eq(l1, l2),
+            (ParametricCell::Arc(a1), ParametricCell::Arc(a2)) => Rc::ptr_eq(a1, a2),
+            (ParametricCell::Circle(c1), ParametricCell::Circle(c2)) => Rc::ptr_eq(c1, c2),
+            _ => false,
+        }
     }
 }
 
-impl Into<ParametricCell> for Primitive {
-    fn into(self) -> ParametricCell {
-        ParametricCell(Rc::new(RefCell::new(self)))
+impl Parametric for ParametricCell {
+    fn references(&self) -> Vec<ParametricCell> {
+        match self {
+            ParametricCell::Point2(p) => p.borrow().references(),
+            ParametricCell::Line(l) => l.borrow().references(),
+            ParametricCell::Arc(a) => a.borrow().references(),
+            ParametricCell::Circle(c) => c.borrow().references(),
+        }
+    }
+
+    fn zero_gradient(&mut self) {
+        match self {
+            ParametricCell::Point2(p) => p.borrow_mut().zero_gradient(),
+            ParametricCell::Line(l) => l.borrow_mut().zero_gradient(),
+            ParametricCell::Arc(a) => a.borrow_mut().zero_gradient(),
+            ParametricCell::Circle(c) => c.borrow_mut().zero_gradient(),
+        }
+    }
+
+    fn get_data(&self) -> DVector<f64> {
+        match self {
+            ParametricCell::Point2(p) => p.borrow().get_data(),
+            ParametricCell::Line(l) => l.borrow().get_data(),
+            ParametricCell::Arc(a) => a.borrow().get_data(),
+            ParametricCell::Circle(c) => c.borrow().get_data(),
+        }
+    }
+
+    fn set_data(&mut self, data: DVectorView<f64>) {
+        match self {
+            ParametricCell::Point2(p) => p.borrow_mut().set_data(data),
+            ParametricCell::Line(l) => l.borrow_mut().set_data(data),
+            ParametricCell::Arc(a) => a.borrow_mut().set_data(data),
+            ParametricCell::Circle(c) => c.borrow_mut().set_data(data),
+        }
+    }
+
+    fn get_gradient(&self) -> DVector<f64> {
+        match self {
+            ParametricCell::Point2(p) => p.borrow().get_gradient(),
+            ParametricCell::Line(l) => l.borrow().get_gradient(),
+            ParametricCell::Arc(a) => a.borrow().get_gradient(),
+            ParametricCell::Circle(c) => c.borrow().get_gradient(),
+        }
+    }
+
+    fn to_primitive(&self) -> Primitive {
+        match self {
+            ParametricCell::Point2(p) => Primitive::Point2(p.borrow().clone()),
+            ParametricCell::Line(l) => Primitive::Line(l.borrow().clone()),
+            ParametricCell::Arc(a) => Primitive::Arc(a.borrow().clone()),
+            ParametricCell::Circle(c) => Primitive::Circle(c.borrow().clone()),
+        }
     }
 }
 
-impl Serialize for ParametricCell {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.0.borrow().to_primitive().serialize(serializer)
-    }
-}
-
-impl<'a> Deserialize<'a> for ParametricCell {
-    fn deserialize<D>(deserializer: D) -> Result<ParametricCell, D::Error>
-    where
-        D: Deserializer<'a>,
-    {
-        let primitive = Primitive::deserialize(deserializer)?;
-        let parametric: Rc<RefCell<dyn Parametric>> = match primitive {
-            // TODO: Macro this
-            Primitive::Arc(inner) => Rc::new(RefCell::new(inner)),
-            Primitive::Circle(inner) => Rc::new(RefCell::new(inner)),
-            Primitive::Line(inner) => Rc::new(RefCell::new(inner)),
-            Primitive::Point2(inner) => Rc::new(RefCell::new(inner)),
-        };
-        Ok(ParametricCell(parametric))
+impl PartialEq for ParametricCell {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ParametricCell::Point2(p1), ParametricCell::Point2(p2)) => Rc::ptr_eq(p1, p2),
+            (ParametricCell::Line(l1), ParametricCell::Line(l2)) => Rc::ptr_eq(l1, l2),
+            (ParametricCell::Arc(a1), ParametricCell::Arc(a2)) => Rc::ptr_eq(a1, a2),
+            (ParametricCell::Circle(c1), ParametricCell::Circle(c2)) => Rc::ptr_eq(c1, c2),
+            _ => false,
+        }
     }
 }

--- a/src/primitives/point2.rs
+++ b/src/primitives/point2.rs
@@ -1,13 +1,10 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use nalgebra::{DVector, DVectorView, SMatrix, SMatrixView, Vector2};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 
-use super::Parametric;
+use super::{Parametric, ParametricCell};
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "tsify", derive(Tsify))]
@@ -57,7 +54,7 @@ impl Point2 {
 }
 
 impl Parametric for Point2 {
-    fn references(&self) -> Vec<Rc<RefCell<dyn Parametric>>> {
+    fn references(&self) -> Vec<ParametricCell> {
         vec![]
     }
 

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -12,7 +12,6 @@ use crate::error::ISOTopeError;
 use crate::primitives::{point2, ParametricCell};
 
 use super::constraints::Constraint;
-use super::primitives::Parametric;
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Sketch {
@@ -28,21 +27,13 @@ impl Sketch {
 
     pub fn add_primitive(&mut self, primitive: ParametricCell) -> Result<u64, ISOTopeError> {
         // Make sure all referenced primitives are added to the sketch before the primitive
-        for reference in primitive.0.borrow().references() {
-            if !self
-                .primitives
-                .iter()
-                .any(|p| Rc::ptr_eq(&p.1 .0, &reference))
-            {
+        for reference in primitive.borrow().references().iter() {
+            if !self.primitives.iter().any(|(_, p)| reference == p) {
                 return Err(ISOTopeError::MissingSketchReferences);
             }
         }
         // Check that the primitive is not already in the sketch
-        if self
-            .primitives
-            .iter()
-            .any(|p| Rc::ptr_eq(&p.1 .0, &primitive.0))
-        {
+        if self.primitives.iter().any(|(_, p)| p == &primitive) {
             return Err(ISOTopeError::PrimitiveAlreadyInSketch);
         }
         // Add the primitive to the sketch
@@ -54,19 +45,17 @@ impl Sketch {
 
     pub fn add_constraint(&mut self, constraint: ConstraintCell) -> Result<(), ISOTopeError> {
         // Make sure all referenced primitives are added to the sketch before the constraint
-        for reference in constraint.0.borrow().references() {
-            if !self
-                .primitives
-                .iter()
-                .any(|p| Rc::ptr_eq(&p.1 .0, &reference))
-            {
+        for reference in constraint.0.borrow().references().iter() {
+            if !self.primitives.iter().any(|(_, p)| p == reference) {
                 return Err(ISOTopeError::MissingSketchReferences);
             }
         }
         // Make sure the constraint is not already in the sketch
-        if self.constraints.iter().any(|c| {
-            Rc::ptr_eq(&c.0, &constraint.0)
-        }) {
+        if self
+            .constraints
+            .iter()
+            .any(|c| Rc::ptr_eq(&c.0, &constraint.0))
+        {
             return Err(ISOTopeError::ConstraintAlreadyInSketch);
         }
 
@@ -100,17 +89,17 @@ impl Sketch {
         Ok(())
     }
 
-    pub fn primitives(&self) -> BTreeMap<u64, Rc<RefCell<dyn Parametric>>> {
+    pub fn primitives(&self) -> BTreeMap<u64, ParametricCell> {
         self.primitives
             .iter()
-            .map(|(k, v)| (*k, v.0.clone()))
+            .map(|(k, v)| (*k, v.clone()))
             .collect()
     }
 
     pub fn get_n_dofs(&self) -> usize {
         let mut n_dofs = 0;
         for primitive in self.primitives.iter() {
-            n_dofs += primitive.1 .0.borrow().get_data().len();
+            n_dofs += primitive.1.borrow().get_data().len();
         }
         n_dofs
     }
@@ -119,7 +108,7 @@ impl Sketch {
         let mut data = DVector::zeros(self.get_n_dofs());
         let mut i = 0;
         for primitive in self.primitives.iter() {
-            let primitive_data = primitive.1 .0.borrow().get_data();
+            let primitive_data = primitive.1.borrow().get_data();
             data.rows_mut(i, primitive_data.len())
                 .copy_from(&primitive_data);
             i += primitive_data.len();
@@ -137,7 +126,7 @@ impl Sketch {
 
     pub fn get_gradient(&mut self) -> DVector<f64> {
         for primitive in self.primitives.iter_mut() {
-            primitive.1 .0.borrow_mut().zero_gradient();
+            primitive.1.borrow_mut().zero_gradient();
         }
 
         for constraint in self.constraints.iter_mut() {
@@ -147,7 +136,7 @@ impl Sketch {
         let mut gradient = DVector::zeros(self.get_n_dofs());
         let mut i = 0;
         for primitive in self.primitives.iter() {
-            let primitive_gradient = primitive.1 .0.borrow().get_gradient();
+            let primitive_gradient = primitive.1.borrow().get_gradient();
             gradient
                 .rows_mut(i, primitive_gradient.len())
                 .copy_from(&primitive_gradient);
@@ -169,14 +158,14 @@ impl Sketch {
         for (i, constraint) in self.constraints.iter().enumerate() {
             // Zero the gradients of all primitives
             for primitive in self.primitives.iter() {
-                primitive.1 .0.borrow_mut().zero_gradient();
+                primitive.1.borrow_mut().zero_gradient();
             }
             // Update the gradient of the constraint
             constraint.0.borrow_mut().update_gradient();
             // Copy the gradient of the constraint to the jacobian
             let mut j = 0;
             for primitive in self.primitives.iter() {
-                let primitive_gradient = primitive.1 .0.borrow().get_gradient();
+                let primitive_gradient = primitive.1.borrow().get_gradient();
                 jacobian
                     .row_mut(i)
                     .columns_mut(j, primitive_gradient.len())
@@ -191,12 +180,8 @@ impl Sketch {
         assert!(data.len() == self.get_n_dofs());
         let mut i = 0;
         for primitive in self.primitives.iter_mut() {
-            let n = primitive.1 .0.borrow().get_data().len();
-            primitive
-                .1
-                 .0
-                .borrow_mut()
-                .set_data(data.rows(i, n).as_view());
+            let n = primitive.1.borrow().get_data().len();
+            primitive.1.borrow_mut().set_data(data.rows(i, n).as_view());
             i += n;
         }
     }
@@ -214,23 +199,21 @@ impl Sketch {
         // Compare to numerical gradients
         let constraint_loss = constraint.borrow().loss_value();
         for primitive in self.primitives.iter_mut() {
-            let original_value = primitive.1 .0.borrow().get_data();
-            let analytical_gradient = primitive.1 .0.borrow().get_gradient();
+            let original_value = primitive.1.borrow().get_data();
+            let analytical_gradient = primitive.1.borrow().get_gradient();
             let mut numerical_gradient = DVector::zeros(original_value.len());
-            let n = primitive.1 .0.borrow().get_data().len();
+            let n = primitive.1.borrow().get_data().len();
             assert!(n == analytical_gradient.len());
             for i in 0..n {
                 let mut new_value = original_value.clone();
                 new_value[i] += epsilon;
                 primitive
                     .1
-                     .0
                     .borrow_mut()
                     .set_data(new_value.clone().as_view());
                 let new_loss = constraint.borrow().loss_value();
                 primitive
                     .1
-                     .0
                     .borrow_mut()
                     .set_data(original_value.clone().as_view());
                 numerical_gradient[i] = (new_loss - constraint_loss) / epsilon;
@@ -250,7 +233,7 @@ impl Sketch {
         self.primitives
             .iter()
             .filter_map(|(k, p)| {
-                if let super::primitives::Primitive::Point2(point) = p.0.borrow().to_primitive() {
+                if let super::primitives::Primitive::Point2(point) = p.borrow().to_primitive() {
                     Some((*k, point))
                 } else {
                     None
@@ -259,10 +242,10 @@ impl Sketch {
             .collect()
     }
 
-    pub fn get_primitive_id(&self, primitive: &Rc<RefCell<dyn Parametric>>) -> Option<u64> {
+    pub fn get_primitive_id(&self, primitive: &ParametricCell) -> Option<u64> {
         self.primitives
             .iter()
-            .find(|(_, p)| Rc::ptr_eq(&p.0, &primitive))
+            .find(|(_, p)| primitive == *p)
             .map(|(k, _)| *k)
     }
 
@@ -293,7 +276,9 @@ mod tests {
             let point = Rc::new(RefCell::new(Point2::new(0.0, 0.0)));
             let arc = Rc::new(RefCell::new(Arc::new(point, 1.0, true, 0.0, 1.0)));
 
-            sketch.add_primitive(ParametricCell(arc.clone())).unwrap();
+            sketch
+                .add_primitive(ParametricCell::Arc(arc.clone()))
+                .unwrap();
         })
         .is_err());
     }
@@ -303,7 +288,7 @@ mod tests {
         assert!(std::panic::catch_unwind(|| {
             let mut sketch = Sketch::new();
 
-            let point = ParametricCell(Rc::new(RefCell::new(Point2::new(0.0, 0.0))));
+            let point = ParametricCell::Point2(Rc::new(RefCell::new(Point2::new(0.0, 0.0))));
             sketch.add_primitive(point.clone()).unwrap();
             sketch.add_primitive(point.clone()).unwrap();
         })
@@ -318,7 +303,9 @@ mod tests {
             let point = Rc::new(RefCell::new(Point2::new(0.0, 0.0)));
             let arc = Rc::new(RefCell::new(Arc::new(point.clone(), 1.0, true, 0.0, 1.0)));
 
-            sketch.add_primitive(ParametricCell(point.clone())).unwrap();
+            sketch
+                .add_primitive(ParametricCell::Point2(point.clone()))
+                .unwrap();
 
             let constraint = Rc::new(RefCell::new(ArcEndPointCoincident::new(arc, point)));
             sketch.add_constraint(ConstraintCell(constraint)).unwrap();
@@ -334,8 +321,12 @@ mod tests {
             let point = Rc::new(RefCell::new(Point2::new(0.0, 0.0)));
             let arc = Rc::new(RefCell::new(Arc::new(point.clone(), 1.0, true, 0.0, 1.0)));
 
-            sketch.add_primitive(ParametricCell(point.clone())).unwrap();
-            sketch.add_primitive(ParametricCell(arc.clone())).unwrap();
+            sketch
+                .add_primitive(ParametricCell::Point2(point.clone()))
+                .unwrap();
+            sketch
+                .add_primitive(ParametricCell::Arc(arc.clone()))
+                .unwrap();
 
             let constraint = Rc::new(RefCell::new(ArcEndPointCoincident::new(
                 arc.clone(),


### PR DESCRIPTION
At first I tried using `Rc<RefCell<Primitive>>`, which made it impossible to downcast without losing the reference.

Then I realised, that `ParametricCell` defined like in the following is all we need. Basically, the trick is to put the `Rc<RefCell<...>>` INSIDE the `enum`, not the `enum` INSIDE the `Rc<RefCell<...>>`

```rust
pub enum ParametricCell {
    Point2(Rc<RefCell<point2::Point2>>),
    Line(Rc<RefCell<line::Line>>),
    Arc(Rc<RefCell<arc::Arc>>),
    Circle(Rc<RefCell<circle::Circle>>),
}
```

Now everything works just nicely, and we dont need any weird serilization logic anymore. Type information can be added or removed from an Parametric-like object without altering its memory location or needing to clone it.
