### PR TITLE
BFGS: Add simple line search with Wolfe conditions

### DIFF
--- a/src/solvers/bfgs_solver.rs
+++ b/src/solvers/bfgs_solver.rs
@@ -72,7 +72,7 @@ impl Solver for BFGSSolver {
             let curvature_condition = WOLFE_C2 * m;
             while alpha > 1e-16 {
                 let new_data = &data + alpha * &p;
-                sketch.borrow_mut().set_data(new_data.clone());
+                sketch.borrow_mut().set_data(new_data);
                 let new_loss = sketch.borrow_mut().get_loss();
                 // Sufficient decrease condition
                 if new_loss <= loss + WOLFE_C1 * alpha * m {


### PR DESCRIPTION
Adds a gradient norm-based termination condition for BFGS and utilizes a backtracking line-search that satisfies the Wolfe conditions. Constants C1 and C2 are taken from the suggestion in Nocedal and Wright.

Note that there are better/smarter line search algorithms (see Algorithm 3.5 in Nocedal and Wright, in particular). But function/gradient evaluations are fairly cheap here. Further benchmarking will be needed to determine if it's worth using more advanced step selection.