### PR TITLE
Handle Ambiguity in RotatedRectangleDemo Positions

### DIFF
--- a/src/examples/test_rectangle_rotated.rs
+++ b/src/examples/test_rectangle_rotated.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::{cell::RefCell, rc::Rc};
 
 use nalgebra::Vector2;
@@ -160,11 +161,83 @@ impl RotatedRectangleDemo {
             point_reference,
         }
     }
+
+    pub fn check(&self, eps: f64) -> Result<(), Box<dyn Error>> {
+        let point_a = self.point_a.as_ref().borrow().data();
+        let point_b = self.point_b.as_ref().borrow().data();
+        let point_c = self.point_c.as_ref().borrow().data();
+        let point_d = self.point_d.as_ref().borrow().data();
+        let point_reference = self.point_reference.as_ref().borrow().data();
+
+        let s2 = f64::sqrt(2.0);
+        let s22 = s2 / 2.;
+
+        if (point_reference - Vector2::new(1.0, 0.0)).norm() >= eps {
+            return Err(format!("point_reference not solved: {:?}", point_reference).into());
+        }
+
+        if (point_a - Vector2::new(0.0, 0.0)).norm() >= eps {
+            return Err(format!("point_a not solved: {:?}", point_a).into());
+        }
+
+        // Problem is under-constrained, look for b above or below the x-axis
+        if point_b[1] < 0. {
+            if (point_b - Vector2::new(s2, -s2)).norm() >= eps {
+                return Err(format!("point_b (below) not solved: {:?}", point_b).into());
+            }
+            // Point c can either be up-and-right of b or down-and-left of b
+            if point_c[1] < point_b[1] {
+                // Point c is down-and-left of b
+                if (point_c - Vector2::new(-s22, -5. * s22)).norm() >= eps {
+                    return Err(format!("point_c (down,left) not solved: {:?}", point_c).into());
+                }
+
+                if (point_d - Vector2::new(-3. * s22, -3. * s22)).norm() >= eps {
+                    return Err(format!("point_d (down,left) not solved: {:?}", point_d).into());
+                }
+            } else {
+                // Point c is up-and-right of b
+                if (point_c - Vector2::new(5. * s22, s22)).norm() >= eps {
+                    return Err(format!("point_c (up,right) not solved: {:?}", point_c).into());
+                }
+
+                if (point_d - Vector2::new(3. * s22, 3. * s22)).norm() >= eps {
+                    return Err(format!("point_d (up,right) not solved: {:?}", point_d).into());
+                }
+            }
+        } else {
+            if (point_b - Vector2::new(s2, s2)).norm() >= eps {
+                return Err(format!("point_b (above) not solved: {:?}", point_b).into());
+            }
+            // Point c can either be up-and-left of b or down-and-right of b
+            if point_c[1] > point_b[1] {
+                // Point c is up-and-left of b
+                if (point_c - Vector2::new(-s22, 5. * s22)).norm() >= eps {
+                    return Err(format!("point_c (up,left) not solved: {:?}", point_c).into());
+                }
+
+                if (point_d - Vector2::new(-3. * s22, 3. * s22)).norm() >= eps {
+                    return Err(format!("point_d (up,left) not solved: {:?}", point_d).into());
+                }
+            } else {
+                // Point c is down-and-right of b
+                if (point_c - Vector2::new(5. * s22, -s22)).norm() >= eps {
+                    return Err(format!("point_c (down,right) not solved: {:?}", point_c).into());
+                }
+
+                if (point_d - Vector2::new(3. * s22, -3. * s22)).norm() >= eps {
+                    return Err(format!("point_d (down,right) not solved: {:?}", point_d).into());
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use nalgebra::Vector2;
+    use std::error::Error;
 
     use crate::{
         examples::test_rectangle_rotated::RotatedRectangleDemo,
@@ -172,7 +245,7 @@ mod tests {
     };
 
     #[test]
-    pub fn test_rectangle_rotated() {
+    pub fn test_rectangle_rotated() -> Result<(), Box<dyn Error>> {
         let rectangle = RotatedRectangleDemo::new();
 
         // Now solve the sketch
@@ -188,30 +261,6 @@ mod tests {
             rectangle.point_reference.as_ref().borrow()
         );
 
-        assert!(
-            (rectangle.point_a.as_ref().borrow().data() - Vector2::new(0.0, 0.0)).norm() < 1e-5
-        );
-        assert!(
-            (rectangle.point_b.as_ref().borrow().data()
-                - Vector2::new(f64::sqrt(2.0), -f64::sqrt(2.0)))
-            .norm()
-                < 1e-5
-        );
-        assert!(
-            (rectangle.point_c.as_ref().borrow().data()
-                - Vector2::new(5.0 / f64::sqrt(2.0), 1.0 / f64::sqrt(2.0)))
-            .norm()
-                < 1e-5
-        );
-        assert!(
-            (rectangle.point_d.as_ref().borrow().data()
-                - Vector2::new(3.0 / f64::sqrt(2.0), 3.0 / f64::sqrt(2.0)))
-            .norm()
-                < 1e-5
-        );
-        assert!(
-            (rectangle.point_reference.as_ref().borrow().data() - Vector2::new(1.0, 0.0)).norm()
-                < 1e-5
-        );
+        rectangle.check(1e-5)
     }
 }

--- a/src/solvers/bfgs_solver.rs
+++ b/src/solvers/bfgs_solver.rs
@@ -119,7 +119,7 @@ impl Solver for BFGSSolver {
 
 #[cfg(test)]
 mod tests {
-    use nalgebra::Vector2;
+    use std::error::Error;
 
     use crate::{
         examples::test_rectangle_rotated::RotatedRectangleDemo,
@@ -127,7 +127,7 @@ mod tests {
     };
 
     #[test]
-    pub fn test_bfgs_solver() {
+    pub fn test_bfgs_solver() -> Result<(), Box<dyn Error>> {
         let rectangle = RotatedRectangleDemo::new();
 
         // Now solve the sketch
@@ -144,30 +144,6 @@ mod tests {
             rectangle.point_reference.as_ref().borrow()
         );
 
-        assert!(
-            (rectangle.point_a.as_ref().borrow().data() - Vector2::new(0.0, 0.0)).norm() < 1e-5
-        );
-        assert!(
-            (rectangle.point_b.as_ref().borrow().data()
-                - Vector2::new(f64::sqrt(2.0), -f64::sqrt(2.0)))
-            .norm()
-                < 1e-5
-        );
-        assert!(
-            (rectangle.point_c.as_ref().borrow().data()
-                - Vector2::new(5.0 / f64::sqrt(2.0), 1.0 / f64::sqrt(2.0)))
-            .norm()
-                < 1e-5
-        );
-        assert!(
-            (rectangle.point_d.as_ref().borrow().data()
-                - Vector2::new(3.0 / f64::sqrt(2.0), 3.0 / f64::sqrt(2.0)))
-            .norm()
-                < 1e-5
-        );
-        assert!(
-            (rectangle.point_reference.as_ref().borrow().data() - Vector2::new(1.0, 0.0)).norm()
-                < 1e-5
-        );
+        rectangle.check(1e-5)
     }
 }

--- a/src/solvers/gauss_newton_solver.rs
+++ b/src/solvers/gauss_newton_solver.rs
@@ -59,7 +59,7 @@ impl Solver for GaussNewtonSolver {
 
 #[cfg(test)]
 mod tests {
-    use nalgebra::Vector2;
+    use std::error::Error;
 
     use crate::{
         examples::test_rectangle_rotated::RotatedRectangleDemo,
@@ -67,7 +67,7 @@ mod tests {
     };
 
     #[test]
-    pub fn test_gauss_newton_solver() {
+    pub fn test_gauss_newton_solver() -> Result<(), Box<dyn Error>> {
         let rectangle = RotatedRectangleDemo::new();
 
         // Now solve the sketch
@@ -84,30 +84,6 @@ mod tests {
             rectangle.point_reference.as_ref().borrow()
         );
 
-        assert!(
-            (rectangle.point_a.as_ref().borrow().data() - Vector2::new(0.0, 0.0)).norm() < 0.01
-        );
-        assert!(
-            (rectangle.point_b.as_ref().borrow().data()
-                - Vector2::new(f64::sqrt(2.0), -f64::sqrt(2.0)))
-            .norm()
-                < 0.1
-        );
-        assert!(
-            (rectangle.point_c.as_ref().borrow().data()
-                - Vector2::new(5.0 / f64::sqrt(2.0), 1.0 / f64::sqrt(2.0)))
-            .norm()
-                < 0.1
-        );
-        assert!(
-            (rectangle.point_d.as_ref().borrow().data()
-                - Vector2::new(3.0 / f64::sqrt(2.0), 3.0 / f64::sqrt(2.0)))
-            .norm()
-                < 0.1
-        );
-        assert!(
-            (rectangle.point_reference.as_ref().borrow().data() - Vector2::new(1.0, 0.0)).norm()
-                < 0.1
-        );
+        rectangle.check(1e-1)
     }
 }

--- a/src/solvers/levenberg_marquardt.rs
+++ b/src/solvers/levenberg_marquardt.rs
@@ -70,7 +70,7 @@ impl Solver for LevenbergMarquardtSolver {
 
 #[cfg(test)]
 mod tests {
-    use nalgebra::Vector2;
+    use std::error::Error;
 
     use crate::{
         examples::test_rectangle_rotated::RotatedRectangleDemo,
@@ -78,7 +78,7 @@ mod tests {
     };
 
     #[test]
-    pub fn test_levenberg_marquardt_solver() {
+    pub fn test_levenberg_marquardt_solver() -> Result<(), Box<dyn Error>> {
         let rectangle = RotatedRectangleDemo::new();
 
         // Now solve the sketch
@@ -95,30 +95,6 @@ mod tests {
             rectangle.point_reference.as_ref().borrow()
         );
 
-        assert!(
-            (rectangle.point_a.as_ref().borrow().data() - Vector2::new(0.0, 0.0)).norm() < 0.01
-        );
-        assert!(
-            (rectangle.point_b.as_ref().borrow().data()
-                - Vector2::new(f64::sqrt(2.0), -f64::sqrt(2.0)))
-            .norm()
-                < 0.1
-        );
-        assert!(
-            (rectangle.point_c.as_ref().borrow().data()
-                - Vector2::new(5.0 / f64::sqrt(2.0), 1.0 / f64::sqrt(2.0)))
-            .norm()
-                < 0.1
-        );
-        assert!(
-            (rectangle.point_d.as_ref().borrow().data()
-                - Vector2::new(3.0 / f64::sqrt(2.0), 3.0 / f64::sqrt(2.0)))
-            .norm()
-                < 0.1
-        );
-        assert!(
-            (rectangle.point_reference.as_ref().borrow().data() - Vector2::new(1.0, 0.0)).norm()
-                < 0.1
-        );
+        rectangle.check(1e-1)
     }
 }


### PR DESCRIPTION
# Overview
Since the `RotatedRectangleDemo` is underspecified and used across the tests for several solvers, this PR adds a method that will check for the four possible outcomes and test their positions to the desired tolerance.

# Details

The `RotatedRectangleDemo` has 7 constraints (for the rectangle):
- Fix A at the origin
- Line AB and BC are perpendicular
- Line BC and CD are perpendicular
- Line CD and DA are perpendicular
- || AB || = 2
- || BC || = 3
- Line AB has an angle with the x-axis of 45 degrees

This leaves two choices for the line segment AB: above the x-axis or below the x-axis. Each of those options has two sub-options corresponding to the two orthogonal directions to the line segment AB. E.g., if AB is above the x-axis, point C can be up-and-left or down-and-right of point B.

This leaves four cases to test for, which this PR adds.

# Alternatives

We could consider adding additional constraints to fully specify the rectangle. However, I think have an underconstrained example is valuable, as it helped catch an erroneous assumption of mine while working on the `GaussNewtonSolver`.