### PR TITLE
Change Solver trait to use mutable reference

### DIFF
--- a/src/constraints/angle_between_points.rs
+++ b/src/constraints/angle_between_points.rs
@@ -181,6 +181,7 @@ impl ConstraintLike for AngleBetweenPoints {
 // Run some tests
 #[cfg(test)]
 mod tests {
+
     use std::{cell::RefCell, rc::Rc};
 
     use crate::constraints::ConstraintCell;
@@ -194,21 +195,18 @@ mod tests {
 
     #[test]
     fn test_angle_between_points() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
+        let mut sketch = Sketch::new();
 
         let point_a = Rc::new(RefCell::new(Point2::new(1.0, 0.0)));
         let point_b = Rc::new(RefCell::new(Point2::new(0.0, 1.0)));
         let point_middle = Rc::new(RefCell::new(Point2::new(0.0, 0.0)));
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_a.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_b.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_middle.clone()))
             .unwrap();
 
@@ -219,7 +217,6 @@ mod tests {
             std::f64::consts::PI / 4.0,
         )));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::AngleBetweenPoints(constr1.clone()))
             .unwrap();
 
@@ -227,11 +224,9 @@ mod tests {
             "current angle: {}",
             constr1.borrow().current_angle() * 180.0 / std::f64::consts::PI
         );
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-6);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-6);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!("point_a: {:?}", point_a.as_ref().borrow());
         println!("point_b: {:?}", point_b.as_ref().borrow());
@@ -247,7 +242,7 @@ mod tests {
 
     #[test]
     fn test_specific_case() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
+        let mut sketch = Sketch::new();
 
         let point_a = Rc::new(RefCell::new(Point2::new(
             0.7805516932908316,
@@ -263,15 +258,12 @@ mod tests {
         )));
 
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_a.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_b.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_middle.clone()))
             .unwrap();
 
@@ -282,15 +274,12 @@ mod tests {
             std::f64::consts::PI / 2.0,
         )));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::AngleBetweenPoints(constr1.clone()))
             .unwrap();
 
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-4);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-4);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!("point_a: {:?}", point_a.as_ref().borrow());
         println!("point_b: {:?}", point_b.as_ref().borrow());

--- a/src/constraints/coincident/arc_end_point_coincident.rs
+++ b/src/constraints/coincident/arc_end_point_coincident.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn test_arc_end_point_coincident() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
+        let mut sketch = Sketch::new();
 
         let center = Rc::new(RefCell::new(Point2::new(0.0, 0.0)));
         let arc1 = Rc::new(RefCell::new(Arc::new(
@@ -115,23 +115,18 @@ mod tests {
             line2_end.clone(),
         )));
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(center.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Arc(arc1.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line2_start.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line2_end.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line2.clone()))
             .unwrap();
 
@@ -140,15 +135,12 @@ mod tests {
             line2_start.clone(),
         )));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::ArcEndPointCoincident(constr1.clone()))
             .unwrap();
 
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-5);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-5);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!("arc1: {:?}", arc1.as_ref().borrow());
         println!("arc1 end point: {:?}", arc1.as_ref().borrow().end_point());

--- a/src/constraints/coincident/arc_start_point_coincident.rs
+++ b/src/constraints/coincident/arc_start_point_coincident.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn test_arc_start_point_coincident() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
+        let mut sketch = Sketch::new();
 
         let center = Rc::new(RefCell::new(Point2::new(0.0, 0.0)));
         let arc1 = Rc::new(RefCell::new(Arc::new(
@@ -115,23 +115,18 @@ mod tests {
             line2_end.clone(),
         )));
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(center.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Arc(arc1.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line2_start.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line2_end.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line2.clone()))
             .unwrap();
 
@@ -140,15 +135,12 @@ mod tests {
             line2_end.clone(),
         )));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::ArcStartPointCoincident(constr1.clone()))
             .unwrap();
 
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-5);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-5);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!("arc1: {:?}", arc1.as_ref().borrow());
         println!(

--- a/src/constraints/distance/euclidian_distance_between_points.rs
+++ b/src/constraints/distance/euclidian_distance_between_points.rs
@@ -137,16 +137,14 @@ mod tests {
 
     #[test]
     fn test_euclidian_distance_between_points() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
+        let mut sketch = Sketch::new();
 
         let point_a = Rc::new(RefCell::new(Point2::new(1.0, 0.0)));
         let point_b = Rc::new(RefCell::new(Point2::new(0.0, 1.0)));
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_a.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_b.clone()))
             .unwrap();
 
@@ -156,15 +154,12 @@ mod tests {
             3.0,
         )));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::EuclideanDistance(constr1.clone()))
             .unwrap();
 
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-6);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-6);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!("point_a: {:?}", point_a.as_ref().borrow());
         println!("point_b: {:?}", point_b.as_ref().borrow());

--- a/src/constraints/distance/horizontal_distance_between_points.rs
+++ b/src/constraints/distance/horizontal_distance_between_points.rs
@@ -134,16 +134,14 @@ mod tests {
 
     #[test]
     fn test_horizontal_distance_between_points() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
+        let mut sketch = Sketch::new();
 
         let point_a = Rc::new(RefCell::new(Point2::new(1.0, 0.0)));
         let point_b = Rc::new(RefCell::new(Point2::new(0.0, 1.0)));
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_a.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_b.clone()))
             .unwrap();
 
@@ -153,15 +151,12 @@ mod tests {
             -3.0,
         )));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::HorizontalDistance(constr1.clone()))
             .unwrap();
 
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-6);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-6);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!("point_a: {:?}", point_a.as_ref().borrow());
         println!("point_b: {:?}", point_b.as_ref().borrow());

--- a/src/constraints/distance/vertical_distance_between_points.rs
+++ b/src/constraints/distance/vertical_distance_between_points.rs
@@ -134,16 +134,14 @@ mod tests {
 
     #[test]
     fn test_vertical_distance_between_points() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
+        let mut sketch = Sketch::new();
 
         let point_a = Rc::new(RefCell::new(Point2::new(1.0, 0.0)));
         let point_b = Rc::new(RefCell::new(Point2::new(0.0, 1.0)));
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_a.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_b.clone()))
             .unwrap();
 
@@ -153,15 +151,12 @@ mod tests {
             3.0,
         )));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::VerticalDistance(constr1.clone()))
             .unwrap();
 
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-6);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-6);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!("point_a: {:?}", point_a.as_ref().borrow());
         println!("point_b: {:?}", point_b.as_ref().borrow());

--- a/src/constraints/fix_point.rs
+++ b/src/constraints/fix_point.rs
@@ -84,11 +84,10 @@ mod tests {
 
     #[test]
     fn test_fix_point() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
+        let mut sketch = Sketch::new();
 
         let point = Rc::new(RefCell::new(Point2::new(1.0, 0.0)));
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point.clone()))
             .unwrap();
 
@@ -97,15 +96,12 @@ mod tests {
             Vector2::new(1.0, 1.0),
         )));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::FixPoint(constr1.clone()))
             .unwrap();
 
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-6);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-6);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!("point: {:?}", point.as_ref().borrow());
         assert!(constr1.borrow().loss_value() < 0.001,);

--- a/src/constraints/lines/equal_length.rs
+++ b/src/constraints/lines/equal_length.rs
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn test_equal_length() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
+        let mut sketch = Sketch::new();
 
         let line1_start = Rc::new(RefCell::new(Point2::new(3.0, 4.0)));
         let line1_end = Rc::new(RefCell::new(Point2::new(5.0, 6.0)));
@@ -120,15 +120,12 @@ mod tests {
             line1_end.clone(),
         )));
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line1_start.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line1_end.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line1.clone()))
             .unwrap();
 
@@ -140,29 +137,23 @@ mod tests {
         )));
 
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line2_start.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line2_end.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line2.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(EqualLength::new(line1.clone(), line2.clone())));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::EqualLength(constr1.clone()))
             .unwrap();
 
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-6);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-6);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!(
             "line1 len: {:?}",

--- a/src/constraints/lines/horizontal_line.rs
+++ b/src/constraints/lines/horizontal_line.rs
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn test_horizontal_line() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
+        let mut sketch = Sketch::new();
 
         let line_start = Rc::new(RefCell::new(Point2::new(3.0, 4.0)));
         let line_end = Rc::new(RefCell::new(Point2::new(5.0, 6.0)));
@@ -91,29 +91,23 @@ mod tests {
             line_end.clone(),
         )));
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line_start.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line_end.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(HorizontalLine::new(line.clone())));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::HorizontalLine(constr1.clone()))
             .unwrap();
 
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-6);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-6);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!("line: {:?}", line.as_ref().borrow());
 

--- a/src/constraints/lines/parallel_lines.rs
+++ b/src/constraints/lines/parallel_lines.rs
@@ -139,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_parallel_line() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
+        let mut sketch = Sketch::new();
 
         let line1_start = Rc::new(RefCell::new(Point2::new(3.0, 4.0)));
         let line1_end = Rc::new(RefCell::new(Point2::new(5.0, 6.0)));
@@ -148,15 +148,12 @@ mod tests {
             line1_end.clone(),
         )));
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line1_start.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line1_end.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line1.clone()))
             .unwrap();
 
@@ -168,15 +165,12 @@ mod tests {
         )));
 
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line2_start.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line2_end.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line2.clone()))
             .unwrap();
 
@@ -185,15 +179,12 @@ mod tests {
             line2.clone(),
         )));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::ParallelLines(constr1.clone()))
             .unwrap();
 
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-6);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-6);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!(
             "line1_dir: {:?}",

--- a/src/constraints/lines/perpendicular_lines.rs
+++ b/src/constraints/lines/perpendicular_lines.rs
@@ -149,8 +149,7 @@ mod tests {
 
     #[test]
     fn test_perpendicular_line() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
-
+        let mut sketch = Sketch::new();
         let line1_start = Rc::new(RefCell::new(Point2::new(3.0, 4.0)));
         let line1_end = Rc::new(RefCell::new(Point2::new(5.0, 6.0)));
         let line1 = Rc::new(RefCell::new(Line::new(
@@ -158,15 +157,12 @@ mod tests {
             line1_end.clone(),
         )));
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line1_start.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line1_end.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line1.clone()))
             .unwrap();
 
@@ -178,15 +174,12 @@ mod tests {
         )));
 
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line2_start.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line2_end.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line2.clone()))
             .unwrap();
 
@@ -195,15 +188,12 @@ mod tests {
             line2.clone(),
         )));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::PerpendicularLines(constr1.clone()))
             .unwrap();
 
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-6);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-6);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!(
             "line1_dir: {:?}",

--- a/src/constraints/lines/vertical_line.rs
+++ b/src/constraints/lines/vertical_line.rs
@@ -82,8 +82,7 @@ mod tests {
 
     #[test]
     fn test_vertical_line() {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
-
+        let mut sketch = Sketch::new();
         let line_start = Rc::new(RefCell::new(Point2::new(3.0, 4.0)));
         let line_end = Rc::new(RefCell::new(Point2::new(5.0, 6.0)));
         let line = Rc::new(RefCell::new(Line::new(
@@ -91,29 +90,23 @@ mod tests {
             line_end.clone(),
         )));
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line_start.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(line_end.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(VerticalLine::new(line.clone())));
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::VerticalLine(constr1.clone()))
             .unwrap();
 
-        sketch
-            .borrow_mut()
-            .check_gradients(1e-6, constr1.clone(), 1e-6);
+        sketch.check_gradients(1e-6, constr1.clone(), 1e-6);
         let solver = GradientBasedSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
         println!("line: {:?}", line.as_ref().borrow());
 

--- a/src/examples/benchmarks/mod.rs
+++ b/src/examples/benchmarks/mod.rs
@@ -21,6 +21,7 @@ mod tests {
         gradient_based_solver::GradientBasedSolver, levenberg_marquardt::LevenbergMarquardtSolver,
         Solver,
     };
+    use std::ops::DerefMut;
 
     use super::{
         circle_with_lines_benchmark::CirclesWithLinesBenchmarkFactory,
@@ -62,7 +63,7 @@ mod tests {
                     let benchmark = benchmark.new_benchmark(*n);
                     let sketch = benchmark.get_sketch();
                     let start = std::time::Instant::now();
-                    solver.solve(sketch.clone()).unwrap();
+                    solver.solve(sketch.borrow_mut().deref_mut()).unwrap();
                     let duration = start.elapsed();
                     let solved = benchmark.check(1e-6);
                     let error = sketch.borrow_mut().get_loss();
@@ -103,7 +104,7 @@ mod tests {
                     let benchmark = benchmark.new_benchmark(*n);
                     let sketch = benchmark.get_sketch();
                     let start = std::time::Instant::now();
-                    solver.solve(sketch.clone()).unwrap();
+                    solver.solve(sketch.borrow_mut().deref_mut()).unwrap();
                     let duration = start.elapsed();
                     let solved = benchmark.check(1e-6);
                     let error = sketch.borrow_mut().get_loss();

--- a/src/examples/test_rectangle_axis_aligned.rs
+++ b/src/examples/test_rectangle_axis_aligned.rs
@@ -22,8 +22,7 @@ mod tests {
     #[test]
     pub fn test_rectangle_axis_aligned() {
         // Create a new empty sketch
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
-
+        let mut sketch = Sketch::new();
         // Create four points
         let point_a = Rc::new(RefCell::new(Point2::new(0.0, 0.0)));
         let point_b = Rc::new(RefCell::new(Point2::new(0.0, 0.0)));
@@ -32,19 +31,15 @@ mod tests {
 
         // Add the points to the sketch
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_a.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_b.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_c.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_d.clone()))
             .unwrap();
 
@@ -56,25 +51,20 @@ mod tests {
 
         // Add the lines to the sketch
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line_a.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line_b.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line_c.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line_d.clone()))
             .unwrap();
 
         // Fix point a to origin
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::FixPoint(Rc::new(RefCell::new(
                 FixPoint::new(point_a.clone(), Vector2::new(0.0, 0.0)),
             ))))
@@ -82,13 +72,11 @@ mod tests {
 
         // Constrain line_a and line_c to be horizontal
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::HorizontalLine(Rc::new(RefCell::new(
                 HorizontalLine::new(line_a.clone()),
             ))))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::HorizontalLine(Rc::new(RefCell::new(
                 HorizontalLine::new(line_c.clone()),
             ))))
@@ -96,13 +84,11 @@ mod tests {
 
         // Constrain line_b and line_d to be vertical
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::VerticalLine(Rc::new(RefCell::new(
                 VerticalLine::new(line_b.clone()),
             ))))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::VerticalLine(Rc::new(RefCell::new(
                 VerticalLine::new(line_d.clone()),
             ))))
@@ -110,7 +96,6 @@ mod tests {
 
         // Constrain the length of line_a to 2
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::HorizontalDistance(Rc::new(RefCell::new(
                 HorizontalDistanceBetweenPoints::new(point_a.clone(), point_b.clone(), 2.0),
             ))))
@@ -118,7 +103,6 @@ mod tests {
 
         // Constrain the length of line_b to 3
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::VerticalDistance(Rc::new(RefCell::new(
                 VerticalDistanceBetweenPoints::new(point_a.clone(), point_d.clone(), 3.0),
             ))))
@@ -126,9 +110,9 @@ mod tests {
 
         // Now solve the sketch
         let solver = BFGSSolver::new();
-        solver.solve(sketch.clone()).unwrap();
+        solver.solve(&mut sketch).unwrap();
 
-        println!("loss = {:?}", sketch.borrow_mut().get_loss());
+        println!("loss = {:?}", sketch.get_loss());
         println!("point_a: {:?}", point_a.as_ref().borrow());
         println!("point_b: {:?}", point_b.as_ref().borrow());
         println!("point_c: {:?}", point_c.as_ref().borrow());

--- a/src/examples/test_rectangle_rotated.rs
+++ b/src/examples/test_rectangle_rotated.rs
@@ -165,6 +165,7 @@ impl RotatedRectangleDemo {
 #[cfg(test)]
 mod tests {
     use nalgebra::Vector2;
+    use std::ops::DerefMut;
 
     use crate::{
         examples::test_rectangle_rotated::RotatedRectangleDemo,
@@ -177,7 +178,9 @@ mod tests {
 
         // Now solve the sketch
         let solver = BFGSSolver::new();
-        solver.solve(rectangle.sketch.clone()).unwrap();
+        solver
+            .solve(rectangle.sketch.borrow_mut().deref_mut())
+            .unwrap();
 
         println!("point_a: {:?}", rectangle.point_a.as_ref().borrow());
         println!("point_b: {:?}", rectangle.point_b.as_ref().borrow());

--- a/src/solvers/bfgs_solver.rs
+++ b/src/solvers/bfgs_solver.rs
@@ -1,7 +1,5 @@
-use std::ops::DerefMut;
-use std::{cell::RefCell, error::Error, rc::Rc};
-
 use nalgebra::{DMatrix, UniformNorm};
+use std::error::Error;
 
 use crate::sketch::Sketch;
 use crate::solvers::line_search::line_search_wolfe;
@@ -32,23 +30,27 @@ impl BFGSSolver {
     }
 }
 
+impl Default for BFGSSolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Solver for BFGSSolver {
-    fn solve(&self, sketch: Rc<RefCell<Sketch>>) -> Result<(), Box<dyn Error>> {
+    fn solve(&self, sketch: &mut Sketch) -> Result<(), Box<dyn Error>> {
         let mut iterations = 0;
+        let mut data = sketch.get_data();
+        let n = data.len();
 
-        let mut h = DMatrix::identity(
-            sketch.borrow().get_data().len(),
-            sketch.borrow().get_data().len(),
-        );
+        let mut h = DMatrix::identity(n, n);
 
-        let mut data = sketch.borrow().get_data();
         while iterations < self.max_iterations {
-            let loss = sketch.borrow_mut().get_loss();
+            let loss = sketch.get_loss();
             if loss < self.min_loss {
                 break;
             }
 
-            let gradient = sketch.borrow_mut().get_gradient();
+            let gradient = sketch.get_gradient();
             if !gradient.iter().all(|x| x.is_finite()) {
                 return Err("gradient contains non-finite values".into());
             }
@@ -62,15 +64,15 @@ impl Solver for BFGSSolver {
                 return Err("search direction contains non-finite values".into());
             }
 
-            let alpha = line_search_wolfe(sketch.borrow_mut().deref_mut(), &p, &gradient)?;
+            let alpha = line_search_wolfe(sketch, &p, &gradient)?;
 
             let s = alpha * &p;
 
             let new_data = &data + &s;
-            sketch.borrow_mut().set_data(new_data.clone());
+            sketch.set_data(new_data.clone());
             data = new_data;
 
-            let new_gradient = sketch.borrow_mut().get_gradient();
+            let new_gradient = sketch.get_gradient();
             let y = &new_gradient - &gradient;
 
             let mut s_dot_y = s.dot(&y);
@@ -99,6 +101,8 @@ impl Solver for BFGSSolver {
 
 #[cfg(test)]
 mod tests {
+    use std::ops::DerefMut;
+
     use nalgebra::Vector2;
 
     use crate::{
@@ -112,7 +116,9 @@ mod tests {
 
         // Now solve the sketch
         let solver = BFGSSolver::new();
-        solver.solve(rectangle.sketch.clone()).unwrap();
+        solver
+            .solve(rectangle.sketch.borrow_mut().deref_mut())
+            .unwrap();
 
         println!("loss: {:?}", rectangle.sketch.borrow_mut().get_loss());
         println!("point_a: {:?}", rectangle.point_a.as_ref().borrow());

--- a/src/solvers/gauss_newton_solver.rs
+++ b/src/solvers/gauss_newton_solver.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, error::Error, rc::Rc};
+use std::error::Error;
 
 use crate::sketch::Sketch;
 
@@ -32,15 +32,15 @@ impl GaussNewtonSolver {
 }
 
 impl Solver for GaussNewtonSolver {
-    fn solve(&self, sketch: Rc<RefCell<Sketch>>) -> Result<(), Box<dyn Error>> {
+    fn solve(&self, sketch: &mut Sketch) -> Result<(), Box<dyn Error>> {
         let mut iterations = 0;
         let mut loss_sum = f64::INFINITY;
 
         while iterations < self.max_iterations && loss_sum > self.min_loss {
-            let mut data = sketch.borrow().get_data();
-            let losses = sketch.borrow().get_loss_per_constraint();
+            let mut data = sketch.get_data();
+            let losses = sketch.get_loss_per_constraint();
             loss_sum = losses.sum();
-            let jacobian = sketch.borrow_mut().get_jacobian();
+            let jacobian = sketch.get_jacobian();
 
             data -= (jacobian.transpose() * jacobian.clone())
                 .clone()
@@ -49,7 +49,7 @@ impl Solver for GaussNewtonSolver {
                 * &losses
                 * self.step_size;
 
-            sketch.borrow_mut().set_data(data);
+            sketch.set_data(data);
 
             iterations += 1;
         }
@@ -60,6 +60,7 @@ impl Solver for GaussNewtonSolver {
 #[cfg(test)]
 mod tests {
     use nalgebra::Vector2;
+    use std::ops::DerefMut;
 
     use crate::{
         examples::test_rectangle_rotated::RotatedRectangleDemo,
@@ -72,17 +73,16 @@ mod tests {
 
         // Now solve the sketch
         let solver = GaussNewtonSolver::new_with_params(500, 1e-8, 1e0);
-        solver.solve(rectangle.sketch.clone()).unwrap();
+        solver
+            .solve(rectangle.sketch.borrow_mut().deref_mut())
+            .unwrap();
 
         println!("loss: {:?}", rectangle.sketch.borrow_mut().get_loss());
-        println!("point_a: {:?}", rectangle.point_a.as_ref().borrow());
-        println!("point_b: {:?}", rectangle.point_b.as_ref().borrow());
-        println!("point_c: {:?}", rectangle.point_c.as_ref().borrow());
-        println!("point_d: {:?}", rectangle.point_d.as_ref().borrow());
-        println!(
-            "point_reference: {:?}",
-            rectangle.point_reference.as_ref().borrow()
-        );
+        println!("point_a: {:?}", rectangle.point_a.as_ref());
+        println!("point_b: {:?}", rectangle.point_b.as_ref());
+        println!("point_c: {:?}", rectangle.point_c.as_ref());
+        println!("point_d: {:?}", rectangle.point_d.as_ref());
+        println!("point_reference: {:?}", rectangle.point_reference.as_ref());
 
         assert!(
             (rectangle.point_a.as_ref().borrow().data() - Vector2::new(0.0, 0.0)).norm() < 0.01

--- a/src/solvers/gradient_based_solver.rs
+++ b/src/solvers/gradient_based_solver.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, error::Error, rc::Rc};
+use std::error::Error;
 
 use crate::sketch::Sketch;
 
@@ -29,18 +29,18 @@ impl GradientBasedSolver {
 }
 
 impl Solver for GradientBasedSolver {
-    fn solve(&self, sketch: Rc<RefCell<Sketch>>) -> Result<(), Box<dyn Error>> {
+    fn solve(&self, sketch: &mut Sketch) -> Result<(), Box<dyn Error>> {
         let mut iterations = 0;
         let mut grad_norm = f64::INFINITY;
 
         while iterations < self.max_iterations && grad_norm > self.min_grad {
-            let mut data = sketch.borrow().get_data();
-            let gradient = sketch.borrow_mut().get_gradient();
+            let mut data = sketch.get_data();
+            let gradient = sketch.get_gradient();
 
             grad_norm = gradient.norm();
             data -= self.step_size * gradient;
 
-            sketch.borrow_mut().set_data(data);
+            sketch.set_data(data);
 
             iterations += 1;
         }

--- a/src/solvers/levenberg_marquardt.rs
+++ b/src/solvers/levenberg_marquardt.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, error::Error, rc::Rc};
+use std::error::Error;
 
 use nalgebra::DMatrix;
 
@@ -42,15 +42,15 @@ impl LevenbergMarquardtSolver {
 }
 
 impl Solver for LevenbergMarquardtSolver {
-    fn solve(&self, sketch: Rc<RefCell<Sketch>>) -> Result<(), Box<dyn Error>> {
+    fn solve(&self, sketch: &mut Sketch) -> Result<(), Box<dyn Error>> {
         let mut iterations = 0;
         let mut loss_sum = f64::INFINITY;
 
         while iterations < self.max_iterations && loss_sum > self.min_loss {
-            let mut data = sketch.borrow().get_data();
-            let losses = sketch.borrow().get_loss_per_constraint();
+            let mut data = sketch.get_data();
+            let losses = sketch.get_loss_per_constraint();
             loss_sum = losses.sum();
-            let jacobian = sketch.borrow_mut().get_jacobian();
+            let jacobian = sketch.get_jacobian();
 
             data -= (jacobian.transpose() * jacobian.clone()
                 + self.beta * DMatrix::identity(jacobian.ncols(), jacobian.ncols()))
@@ -60,7 +60,7 @@ impl Solver for LevenbergMarquardtSolver {
                 * &losses
                 * self.step_size;
 
-            sketch.borrow_mut().set_data(data);
+            sketch.set_data(data);
 
             iterations += 1;
         }
@@ -70,6 +70,8 @@ impl Solver for LevenbergMarquardtSolver {
 
 #[cfg(test)]
 mod tests {
+    use std::ops::DerefMut;
+
     use nalgebra::Vector2;
 
     use crate::{
@@ -83,17 +85,16 @@ mod tests {
 
         // Now solve the sketch
         let solver = LevenbergMarquardtSolver::new_with_params(1000, 1e-10, 1e-1, 1e-5);
-        solver.solve(rectangle.sketch.clone()).unwrap();
+        solver
+            .solve(rectangle.sketch.borrow_mut().deref_mut())
+            .unwrap();
 
         println!("loss: {:?}", rectangle.sketch.borrow_mut().get_loss());
-        println!("point_a: {:?}", rectangle.point_a.as_ref().borrow());
-        println!("point_b: {:?}", rectangle.point_b.as_ref().borrow());
-        println!("point_c: {:?}", rectangle.point_c.as_ref().borrow());
-        println!("point_d: {:?}", rectangle.point_d.as_ref().borrow());
-        println!(
-            "point_reference: {:?}",
-            rectangle.point_reference.as_ref().borrow()
-        );
+        println!("point_a: {:?}", rectangle.point_a.as_ref());
+        println!("point_b: {:?}", rectangle.point_b.as_ref());
+        println!("point_c: {:?}", rectangle.point_c.as_ref());
+        println!("point_d: {:?}", rectangle.point_d.as_ref());
+        println!("point_reference: {:?}", rectangle.point_reference.as_ref());
 
         assert!(
             (rectangle.point_a.as_ref().borrow().data() - Vector2::new(0.0, 0.0)).norm() < 0.01

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, error::Error, rc::Rc};
+use std::error::Error;
 
 use crate::sketch::Sketch;
 
@@ -10,5 +10,5 @@ pub mod gradient_based_solver;
 pub mod levenberg_marquardt;
 
 pub trait Solver {
-    fn solve(&self, sketch: Rc<RefCell<Sketch>>) -> Result<(), Box<dyn Error>>;
+    fn solve(&self, sketch: &mut Sketch) -> Result<(), Box<dyn Error>>;
 }


### PR DESCRIPTION
# Overview

Since the `solve` method of the solvers requires an exclusive reference to perform `borrow_mut()`, the solve method can use a mutable reference directly which saves on some levels of indirection.

Cases where existing `Rc<RefCell<Sketch>>`'s need to solve can be handled by changing `.clone()` to `.borrow_mut().deref_mut()`.