### PR TITLE
Satisfy Clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -52,4 +52,4 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-features -- -D warnings
+      - run: cargo clippy --all-features -- -D warnings -A clippy::empty_docs

--- a/src/decompose/mod.rs
+++ b/src/decompose/mod.rs
@@ -4,7 +4,8 @@ use std::f64::consts::{PI, TAU};
 use geo::Polygon;
 use geo::{Contains as _, InteriorPoint as _};
 
-use crate::{primitives::Primitive, sketch::Sketch};
+use crate::primitives::PrimitiveCell;
+use crate::sketch::Sketch;
 
 use self::face::Face;
 use self::ring::Ring;
@@ -36,12 +37,13 @@ pub fn merge_faces(faces: Vec<Face>) -> Vec<Face> {
     for (new_face_idx, face) in faces.iter().enumerate() {
         let as_geo_polygon = face.as_polygon();
 
+        #[allow(clippy::expect_used)]
         let random_point_on_face = as_geo_polygon
             .interior_point()
             .expect("Every polygon should be able to yield an interior point");
 
         let mut located = false;
-        for (_old_face_idx, old_face) in old_faces_as_polygons.iter().enumerate() {
+        for old_face in old_faces_as_polygons.iter() {
             if old_face.contains(&random_point_on_face) {
                 // this means the old face contains the random point on the new face
                 // so we can keep this new face
@@ -71,7 +73,7 @@ pub fn find_faces(sketch: &Sketch) -> (Vec<Face>, Vec<Segment>) {
     let (rings, unused_segments) = find_rings(sketch);
     let mut faces: Vec<Face> = rings.iter().map(|r| Face::from_ring(r.clone())).collect();
 
-    if rings.len() == 0 {
+    if rings.is_empty() {
         return (faces, unused_segments);
     }
 
@@ -82,11 +84,12 @@ pub fn find_faces(sketch: &Sketch) -> (Vec<Face>, Vec<Segment>) {
     // they are already sorted from smallest to largest area - self.find_rings does this
     let mut what_contains_what: Vec<(usize, usize)> = vec![];
 
-    for smaller_polygon_index in 0..polygons.len() - 1 {
-        let smaller_polygon = &polygons[smaller_polygon_index];
-
-        for bigger_polygon_index in smaller_polygon_index + 1..polygons.len() {
-            let bigger_polygon = &polygons[bigger_polygon_index];
+    for (smaller_polygon_index, smaller_polygon) in
+        polygons[..polygons.len() - 1].iter().enumerate()
+    {
+        for (bigger_polygon_index, bigger_polygon) in
+            polygons[smaller_polygon_index + 1..].iter().enumerate()
+        {
             let inside = bigger_polygon.contains(smaller_polygon);
 
             if inside {
@@ -107,97 +110,87 @@ pub fn find_faces(sketch: &Sketch) -> (Vec<Face>, Vec<Segment>) {
 }
 
 pub fn find_rings(sketch: &Sketch) -> (Vec<Ring>, Vec<Segment>) {
-    let init_segments = sketch
+    let init_segments: Vec<Segment> = sketch
         .primitives()
-        .iter()
-        .map(|p| p.1.borrow().to_primitive())
+        .values()
         .filter_map(|p| match p {
             // We don't consider circles - we'll just add them to the rings directly (right?)
-            Primitive::Line(l) => Some(Segment::Line(l)),
-            Primitive::Arc(a) => Some(Segment::Arc(a)),
+            PrimitiveCell::Line(l) => Some(Segment::Line(l.borrow().clone())),
+            PrimitiveCell::Arc(a) => Some(Segment::Arc(a.borrow().clone())),
             _ => None,
         })
-        .collect::<Vec<Segment>>();
-    let init_segments_len = init_segments.len();
-    let segments_reversed = init_segments
-        .iter()
-        .map(|s| s.reverse())
-        .collect::<Vec<Segment>>();
+        .collect();
+
+    let segments_reversed = init_segments.iter().map(|s| s.reverse());
 
     // We consider all given segments and their reversed counterparts
-    let all_segments = vec![init_segments, segments_reversed].concat();
+    let all_segments: Vec<Segment> = init_segments
+        .iter()
+        .cloned()
+        .chain(segments_reversed)
+        .collect();
 
-    let mut used_indices: Vec<usize> = vec![];
-    let mut new_rings: Vec<Vec<usize>> = vec![];
+    let mut used_indices: BTreeSet<usize> = BTreeSet::new();
+    let mut new_rings: Vec<Vec<&Segment>> = vec![];
 
     for (segment_index, segment) in all_segments.iter().enumerate() {
         if used_indices.contains(&segment_index) {
             continue;
         }
 
-        let mut new_ring_indices: Vec<usize> = vec![];
+        let mut new_ring_indices: Vec<(usize, &Segment)> = vec![];
         let start_point = segment.get_start();
 
         let mut next_segment_index = segment_index;
+        let mut next_segment = segment;
         for _i in 1..all_segments.len() {
-            let next_segment = all_segments.get(next_segment_index).unwrap();
-            new_ring_indices.push(next_segment_index);
-
-            next_segment_index = if let Some(index) =
-                find_next_segment_index(&all_segments, next_segment, &used_indices)
-            {
-                index
-            } else {
-                break;
-            };
+            new_ring_indices.push((next_segment_index, next_segment));
 
             if next_segment.get_end() == start_point {
-                new_rings.push(new_ring_indices.clone());
-                used_indices.extend(new_ring_indices);
+                new_rings.push(new_ring_indices.iter().map(|x| x.1).collect());
+                used_indices.extend(new_ring_indices.iter().map(|x| x.0));
                 break;
             }
+
+            (next_segment_index, next_segment) =
+                match find_next_segment(&all_segments, next_segment, &used_indices) {
+                    Some((index, segment)) => (index, segment),
+                    None => break,
+                };
         }
     }
 
-    let used_indices_set = used_indices.into_iter().collect::<BTreeSet<_>>();
-    let all_indices_set = (0..all_segments.len()).collect::<BTreeSet<_>>();
-
-    let unused_indices_set = all_indices_set
-        .difference(&used_indices_set)
-        .collect::<BTreeSet<_>>();
-    let unused_indices = unused_indices_set
+    let unused_segments = init_segments
         .iter()
-        .cloned()
-        .filter(|index| *index < &init_segments_len)
-        .collect::<Vec<_>>();
-    let unused_segments = unused_indices
-        .iter()
-        .map(|index| all_segments.get(**index).unwrap().clone())
+        .enumerate()
+        .filter_map(|(index, segment)| {
+            if used_indices.contains(&index) {
+                None
+            } else {
+                Some(segment.clone())
+            }
+        })
         .collect::<Vec<_>>();
 
     let mut all_rings: Vec<Ring> = vec![];
     for ring_indices in new_rings {
-        let ring_segments = ring_indices
-            .iter()
-            .map(|index| all_segments.get(*index).unwrap().clone())
-            .collect::<Vec<_>>();
+        let ring_segments = ring_indices.into_iter().cloned().collect::<Vec<_>>();
         all_rings.push(Ring::Segments(ring_segments));
     }
 
     // Circles are rings too
     let circles = sketch
         .primitives()
-        .iter()
-        .map(|p| p.1.borrow().to_primitive())
+        .values()
         .filter_map(|s| match s {
-            Primitive::Circle(c) => Some(Ring::Circle(c.clone())),
+            PrimitiveCell::Circle(c) => Some(Ring::Circle(c.borrow().clone())),
             _ => None,
         })
         .collect::<Vec<_>>();
     all_rings.extend(circles);
 
     // Need to implement signed_area
-    all_rings.sort_by(|a, b| a.signed_area().partial_cmp(&b.signed_area()).unwrap());
+    all_rings.sort_by(|a, b| a.signed_area().total_cmp(&b.signed_area()));
 
     all_rings = all_rings
         .iter()
@@ -208,23 +201,22 @@ pub fn find_rings(sketch: &Sketch) -> (Vec<Ring>, Vec<Segment>) {
     (all_rings, unused_segments)
 }
 
-pub fn find_next_segment_index(
-    segments: &Vec<Segment>,
+pub fn find_next_segment<'seg>(
+    segments: impl IntoIterator<Item = &'seg Segment>,
     current_segment: &Segment,
-    used_indices: &Vec<usize>,
-) -> Option<usize> {
-    let mut matches: Vec<(usize, f64, f64)> = vec![];
-    let mut this_segment_end_angle = current_segment.end_angle();
-    this_segment_end_angle = (this_segment_end_angle + PI) % (2.0 * PI);
+    used_indices: &BTreeSet<usize>,
+) -> Option<(usize, &'seg Segment)> {
+    let mut matches: Vec<((usize, &Segment), f64)> = vec![];
+    let this_segment_end_angle = (current_segment.end_angle() + PI) % (2.0 * PI);
 
-    for (idx, s2) in segments.iter().enumerate() {
+    for (idx, s2) in segments.into_iter().enumerate() {
         if used_indices.contains(&idx) {
             continue;
         }
-        if s2.continues(&current_segment) && !s2.equals_or_reverse_equals(&current_segment) {
+        if s2.continues(current_segment) && !s2.equals_or_reverse_equals(current_segment) {
             let starting_angle = s2.start_angle();
             let angle_diff = angle_difference(this_segment_end_angle, starting_angle);
-            matches.push((idx, starting_angle, angle_diff));
+            matches.push(((idx, s2), angle_diff));
             // angle_diff measures how hard you'd have to turn left to continue the path from
             // starting_segment to s2, where a straight line would be 180, a left turn 270, a right turn 90.
             // This is important later because to make the smallest loops possible, we always want to be
@@ -232,23 +224,10 @@ pub fn find_next_segment_index(
         }
     }
 
-    if matches.len() == 0 {
-        None
-    } else if matches.len() == 1 {
-        Some(matches[0].0)
-    } else {
-        let mut best_option = 0;
-        let mut hardest_left_turn = 0.0;
-
-        for o in matches.iter() {
-            if o.2 > hardest_left_turn {
-                hardest_left_turn = o.2;
-                best_option = o.0;
-            }
-        }
-
-        Some(best_option)
-    }
+    matches
+        .iter()
+        .reduce(|a, b| if a.1 > b.1 { a } else { b })
+        .map(|x| x.0)
 }
 
 pub fn angle_difference(mut a0: f64, mut a1: f64) -> f64 {

--- a/src/decompose/ring.rs
+++ b/src/decompose/ring.rs
@@ -67,7 +67,6 @@ impl Ring {
                     b.push((x, y));
                 }
 
-                
                 Polygon::new(LineString::from(b), vec![])
             }
             Ring::Segments(segments) => {

--- a/src/decompose/ring.rs
+++ b/src/decompose/ring.rs
@@ -42,8 +42,8 @@ impl Ring {
                         }
                     }
                 }
-                if edge_indices_a.len() == 0 {
-                    return None;
+                if edge_indices_a.is_empty() {
+                    None
                 } else {
                     Some((edge_indices_a, edge_indices_b))
                 }
@@ -67,8 +67,8 @@ impl Ring {
                     b.push((x, y));
                 }
 
-                let polygon = Polygon::new(LineString::from(b), vec![]);
-                polygon
+                
+                Polygon::new(LineString::from(b), vec![])
             }
             Ring::Segments(segments) => {
                 // we only ever push the start point. Imagine what happens for a closed

--- a/src/examples/benchmarks/circle_with_lines_benchmark.rs
+++ b/src/examples/benchmarks/circle_with_lines_benchmark.rs
@@ -19,7 +19,7 @@ pub fn circle(n: usize) -> Vec<Vector2<f64>> {
     let mut points = Vec::new();
     for i in 0..n {
         let x = ((i + 1) / 2) as f64 * 0.8;
-        let y = ((i + 0) / 2) as f64 * 0.8;
+        let y = (i / 2) as f64 * 0.8;
         points.push(Vector2::new(x, y));
     }
     points

--- a/src/examples/benchmarks/stairs_with_lines_benchmark.rs
+++ b/src/examples/benchmarks/stairs_with_lines_benchmark.rs
@@ -116,7 +116,7 @@ impl Benchmark for StairsWithLinesBenchmark {
         for i in 0..self.point_references.len() - 1 {
             let point = self.point_references[i].as_ref().borrow();
             let true_x = ((i + 1) / 2) as f64 * 0.8;
-            let true_y = ((i + 0) / 2) as f64 * 0.8;
+            let true_y = (i / 2) as f64 * 0.8;
             if (point.x() - true_x).abs() > eps || (point.y() - true_y).abs() > eps {
                 return false;
             }

--- a/src/examples/test_rectangle_rotated.rs
+++ b/src/examples/test_rectangle_rotated.rs
@@ -21,6 +21,12 @@ pub struct RotatedRectangleDemo {
     pub point_reference: Rc<RefCell<Point2>>,
 }
 
+impl Default for RotatedRectangleDemo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RotatedRectangleDemo {
     pub fn new() -> Self {
         let sketch = Rc::new(RefCell::new(Sketch::new()));

--- a/src/solvers/bfgs_solver.rs
+++ b/src/solvers/bfgs_solver.rs
@@ -14,6 +14,12 @@ pub struct BFGSSolver {
     gradient_threshold: f64,
 }
 
+impl Default for BFGSSolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BFGSSolver {
     pub fn new() -> Self {
         Self {

--- a/src/solvers/gauss_newton_solver.rs
+++ b/src/solvers/gauss_newton_solver.rs
@@ -11,6 +11,12 @@ pub struct GaussNewtonSolver {
     pseudo_inverse_eps: f64,
 }
 
+impl Default for GaussNewtonSolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GaussNewtonSolver {
     pub fn new() -> Self {
         Self {

--- a/src/solvers/gradient_based_solver.rs
+++ b/src/solvers/gradient_based_solver.rs
@@ -10,6 +10,12 @@ pub struct GradientBasedSolver {
     step_size: f64,
 }
 
+impl Default for GradientBasedSolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GradientBasedSolver {
     pub fn new() -> Self {
         Self {

--- a/src/solvers/levenberg_marquardt.rs
+++ b/src/solvers/levenberg_marquardt.rs
@@ -14,6 +14,12 @@ pub struct LevenbergMarquardtSolver {
     beta: f64,
 }
 
+impl Default for LevenbergMarquardtSolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LevenbergMarquardtSolver {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
# Overview

Makes some tweaks to satisfy Clippy. 

# Details

- Add implementations for `Default` for structs with a `::new()` with no params.
- Allow `empty_docs`. These seem to be generated by `derive(Tsify)`/`wasm_bindgen`. In particular, it generates the following: 
```rust
        #[automatically_derived]
        ///
        #[repr(transparent)]
        pub struct JsType {
            obj: wasm_bindgen::JsValue,
        }
``` 
- Adds tests for `decompose::find_rings` to support refactoring.
- Use references rather than index + `.get()` to avoid unwrapping options in `find_rings`.