### PR TITLE
Solvers: Avoid non-terminating condition in line search

### DIFF
--- a/src/solvers/line_search.rs
+++ b/src/solvers/line_search.rs
@@ -1,28 +1,37 @@
 use crate::sketch::Sketch;
 use nalgebra::DVector;
-use std::error::Error;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LineSearchError {
+    #[error("line search failed: search direction is not a descent direction")]
+    NotDescentDirection,
+    #[error("line search failed: could not find a suitable step size")]
+    SearchFailed,
+}
 
 const WOLFE_C1: f64 = 1e-4;
 const WOLFE_C2: f64 = 0.9;
+const MAX_ITER: usize = 15;
 
 pub(crate) fn line_search_wolfe(
     sketch: &mut Sketch,
     direction: &DVector<f64>,
     gradient: &DVector<f64>,
-) -> Result<f64, Box<dyn Error>> {
+) -> Result<f64, LineSearchError> {
     let mut alpha = 1.0;
     let m = gradient.dot(direction);
     if m >= 0.0 {
-        return Err("line search failed: search direction is not a descent direction".into());
+        return Err(LineSearchError::NotDescentDirection);
     }
     let curvature_condition = WOLFE_C2 * m;
     let loss = sketch.get_loss();
     let x0 = sketch.get_data();
-    while alpha > 1e-16 {
+    for _i in 0..MAX_ITER {
         let data = &x0 + alpha * direction;
         sketch.set_data(data);
         let new_loss = sketch.get_loss();
-        // Sufficent decrease condition
+        // Sufficient decrease condition
         if new_loss <= loss + WOLFE_C1 * alpha * m {
             // Curvature condition
             let new_gradient = sketch.get_gradient();
@@ -35,5 +44,5 @@ pub(crate) fn line_search_wolfe(
             alpha *= 0.5;
         }
     }
-    Err("line search failed: alpha is too small".into())
+    Err(LineSearchError::SearchFailed)
 }


### PR DESCRIPTION
This commit replaces the potentially infinite loop in the line search with a finite number of iterations. In infinite precision arithmetic, the loop is guaranteed to terminate. However, with floating point precision, it's possible for the search direction to be nearly orthogonal to the gradient and for there not to be a valid step.