### PR TITLE
More developer friendly interface

### DIFF
--- a/src/constraints/angle_between_points.rs
+++ b/src/constraints/angle_between_points.rs
@@ -182,6 +182,7 @@ impl ConstraintLike for AngleBetweenPoints {
 #[cfg(test)]
 mod tests {
 
+    use std::error::Error;
     use std::{cell::RefCell, rc::Rc};
 
     use crate::constraints::ConstraintCell;
@@ -241,31 +242,12 @@ mod tests {
     }
 
     #[test]
-    fn test_specific_case() {
+    fn test_specific_case() -> Result<(), Box<dyn Error>> {
         let mut sketch = Sketch::new();
 
-        let point_a = Rc::new(RefCell::new(Point2::new(
-            0.7805516932908316,
-            -0.00782612334736288,
-        )));
-        let point_b = Rc::new(RefCell::new(Point2::new(
-            1.22103191002294,
-            0.004601914768224987,
-        )));
-        let point_middle = Rc::new(RefCell::new(Point2::new(
-            0.013589691730458502,
-            -0.10039941813640837,
-        )));
-
-        sketch
-            .add_primitive(PrimitiveCell::Point2(point_a.clone()))
-            .unwrap();
-        sketch
-            .add_primitive(PrimitiveCell::Point2(point_b.clone()))
-            .unwrap();
-        sketch
-            .add_primitive(PrimitiveCell::Point2(point_middle.clone()))
-            .unwrap();
+        let point_a = sketch.add_point2(0.7805516932908316, -0.00782612334736288)?;
+        let point_b = sketch.add_point2(1.22103191002294, 0.004601914768224987)?;
+        let point_middle = sketch.add_point2(0.013589691730458502, -0.10039941813640837)?;
 
         let constr1 = Rc::new(RefCell::new(AngleBetweenPoints::new(
             point_a.clone(),
@@ -291,5 +273,6 @@ mod tests {
         );
 
         assert!(constr1.borrow().loss_value() < 0.001,);
+        Ok(())
     }
 }

--- a/src/constraints/coincident/arc_end_point_coincident.rs
+++ b/src/constraints/coincident/arc_end_point_coincident.rs
@@ -91,7 +91,7 @@ mod tests {
         constraints::{
             coincident::arc_end_point_coincident::ArcEndPointCoincident, ConstraintCell,
         },
-        primitives::{arc::Arc, line::Line, point2::Point2, PrimitiveCell},
+        primitives::{arc::Arc, PrimitiveCell},
         sketch::Sketch,
         solvers::{gradient_based_solver::GradientBasedSolver, Solver},
     };
@@ -100,7 +100,7 @@ mod tests {
     fn test_arc_end_point_coincident() {
         let mut sketch = Sketch::new();
 
-        let center = Rc::new(RefCell::new(Point2::new(0.0, 0.0)));
+        let center = sketch.add_point2(0.0, 0.0).unwrap();
         let arc1 = Rc::new(RefCell::new(Arc::new(
             center.clone(),
             1.0,
@@ -108,26 +108,14 @@ mod tests {
             0.0,
             std::f64::consts::PI,
         )));
-        let line2_start = Rc::new(RefCell::new(Point2::new(3.0, 4.0)));
-        let line2_end = Rc::new(RefCell::new(Point2::new(5.0, 6.0)));
-        let line2 = Rc::new(RefCell::new(Line::new(
-            line2_start.clone(),
-            line2_end.clone(),
-        )));
-        sketch
-            .add_primitive(PrimitiveCell::Point2(center.clone()))
+        let line2_start = sketch.add_point2(3.0, 4.0).unwrap();
+        let line2_end = sketch.add_point2(5.0, 6.0).unwrap();
+
+        let line2 = sketch
+            .add_line(line2_start.clone(), line2_end.clone())
             .unwrap();
         sketch
             .add_primitive(PrimitiveCell::Arc(arc1.clone()))
-            .unwrap();
-        sketch
-            .add_primitive(PrimitiveCell::Point2(line2_start.clone()))
-            .unwrap();
-        sketch
-            .add_primitive(PrimitiveCell::Point2(line2_end.clone()))
-            .unwrap();
-        sketch
-            .add_primitive(PrimitiveCell::Line(line2.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(ArcEndPointCoincident::new(

--- a/src/constraints/coincident/arc_start_point_coincident.rs
+++ b/src/constraints/coincident/arc_start_point_coincident.rs
@@ -85,50 +85,37 @@ impl ConstraintLike for ArcStartPointCoincident {
 // Run some tests
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, rc::Rc};
+    use std::{cell::RefCell, error::Error, rc::Rc};
 
     use crate::{
         constraints::{
             coincident::arc_start_point_coincident::ArcStartPointCoincident, ConstraintCell,
         },
-        primitives::{arc::Arc, PrimitiveCell},
         sketch::Sketch,
         solvers::{gradient_based_solver::GradientBasedSolver, Solver},
     };
 
     #[test]
-    fn test_arc_start_point_coincident() {
+    fn test_arc_start_point_coincident() -> Result<(), Box<dyn Error>> {
         let mut sketch = Sketch::new();
 
-        let center = sketch.add_point2(0.0, 0.0).unwrap();
-        let arc1 = Rc::new(RefCell::new(Arc::new(
-            center.clone(),
-            1.0,
-            false,
-            0.0,
-            std::f64::consts::PI,
-        )));
-        let line2_start = sketch.add_point2(3.0, 4.0).unwrap();
-        let line2_end = sketch.add_point2(5.0, 6.0).unwrap();
+        let center = sketch.add_point2(0.0, 0.0)?;
 
-        let line2 = sketch
-            .add_line(line2_start.clone(), line2_end.clone())
-            .unwrap();
-        sketch
-            .add_primitive(PrimitiveCell::Arc(arc1.clone()))
-            .unwrap();
+        let arc1 = sketch.add_arc(center.clone(), 1.0, false, 0.0, std::f64::consts::PI)?;
+        let line2_start = sketch.add_point2(3.0, 4.0)?;
+        let line2_end = sketch.add_point2(5.0, 6.0)?;
+
+        let line2 = sketch.add_line(line2_start.clone(), line2_end.clone())?;
 
         let constr1 = Rc::new(RefCell::new(ArcStartPointCoincident::new(
             arc1.clone(),
             line2_end.clone(),
         )));
-        sketch
-            .add_constraint(ConstraintCell::ArcStartPointCoincident(constr1.clone()))
-            .unwrap();
+        sketch.add_constraint(ConstraintCell::ArcStartPointCoincident(constr1.clone()))?;
 
         sketch.check_gradients(1e-6, constr1.clone(), 1e-5);
         let solver = GradientBasedSolver::new();
-        solver.solve(&mut sketch).unwrap();
+        solver.solve(&mut sketch)?;
 
         println!("arc1: {:?}", arc1.as_ref().borrow());
         println!(
@@ -147,5 +134,6 @@ mod tests {
                 .abs()
                 < 1e-6
         );
+        Ok(())
     }
 }

--- a/src/constraints/coincident/arc_start_point_coincident.rs
+++ b/src/constraints/coincident/arc_start_point_coincident.rs
@@ -91,7 +91,7 @@ mod tests {
         constraints::{
             coincident::arc_start_point_coincident::ArcStartPointCoincident, ConstraintCell,
         },
-        primitives::{arc::Arc, line::Line, point2::Point2, PrimitiveCell},
+        primitives::{arc::Arc, PrimitiveCell},
         sketch::Sketch,
         solvers::{gradient_based_solver::GradientBasedSolver, Solver},
     };
@@ -100,7 +100,7 @@ mod tests {
     fn test_arc_start_point_coincident() {
         let mut sketch = Sketch::new();
 
-        let center = Rc::new(RefCell::new(Point2::new(0.0, 0.0)));
+        let center = sketch.add_point2(0.0, 0.0).unwrap();
         let arc1 = Rc::new(RefCell::new(Arc::new(
             center.clone(),
             1.0,
@@ -108,26 +108,14 @@ mod tests {
             0.0,
             std::f64::consts::PI,
         )));
-        let line2_start = Rc::new(RefCell::new(Point2::new(3.0, 4.0)));
-        let line2_end = Rc::new(RefCell::new(Point2::new(5.0, 6.0)));
-        let line2 = Rc::new(RefCell::new(Line::new(
-            line2_start.clone(),
-            line2_end.clone(),
-        )));
-        sketch
-            .add_primitive(PrimitiveCell::Point2(center.clone()))
+        let line2_start = sketch.add_point2(3.0, 4.0).unwrap();
+        let line2_end = sketch.add_point2(5.0, 6.0).unwrap();
+
+        let line2 = sketch
+            .add_line(line2_start.clone(), line2_end.clone())
             .unwrap();
         sketch
             .add_primitive(PrimitiveCell::Arc(arc1.clone()))
-            .unwrap();
-        sketch
-            .add_primitive(PrimitiveCell::Point2(line2_start.clone()))
-            .unwrap();
-        sketch
-            .add_primitive(PrimitiveCell::Point2(line2_end.clone()))
-            .unwrap();
-        sketch
-            .add_primitive(PrimitiveCell::Line(line2.clone()))
             .unwrap();
 
         let constr1 = Rc::new(RefCell::new(ArcStartPointCoincident::new(

--- a/src/constraints/distance/euclidian_distance_between_points.rs
+++ b/src/constraints/distance/euclidian_distance_between_points.rs
@@ -130,7 +130,6 @@ mod tests {
             distance::euclidian_distance_between_points::EuclidianDistanceBetweenPoints,
             ConstraintCell, ConstraintLike,
         },
-        primitives::{point2::Point2, PrimitiveCell},
         sketch::Sketch,
         solvers::{gradient_based_solver::GradientBasedSolver, Solver},
     };
@@ -139,14 +138,8 @@ mod tests {
     fn test_euclidian_distance_between_points() {
         let mut sketch = Sketch::new();
 
-        let point_a = Rc::new(RefCell::new(Point2::new(1.0, 0.0)));
-        let point_b = Rc::new(RefCell::new(Point2::new(0.0, 1.0)));
-        sketch
-            .add_primitive(PrimitiveCell::Point2(point_a.clone()))
-            .unwrap();
-        sketch
-            .add_primitive(PrimitiveCell::Point2(point_b.clone()))
-            .unwrap();
+        let point_a = sketch.add_point2(1.0, 0.0).unwrap();
+        let point_b = sketch.add_point2(0.0, 1.0).unwrap();
 
         let constr1 = Rc::new(RefCell::new(EuclidianDistanceBetweenPoints::new(
             point_a.clone(),

--- a/src/constraints/distance/horizontal_distance_between_points.rs
+++ b/src/constraints/distance/horizontal_distance_between_points.rs
@@ -127,7 +127,6 @@ mod tests {
             distance::horizontal_distance_between_points::HorizontalDistanceBetweenPoints,
             ConstraintCell, ConstraintLike,
         },
-        primitives::{point2::Point2, PrimitiveCell},
         sketch::Sketch,
         solvers::{gradient_based_solver::GradientBasedSolver, Solver},
     };
@@ -136,14 +135,8 @@ mod tests {
     fn test_horizontal_distance_between_points() {
         let mut sketch = Sketch::new();
 
-        let point_a = Rc::new(RefCell::new(Point2::new(1.0, 0.0)));
-        let point_b = Rc::new(RefCell::new(Point2::new(0.0, 1.0)));
-        sketch
-            .add_primitive(PrimitiveCell::Point2(point_a.clone()))
-            .unwrap();
-        sketch
-            .add_primitive(PrimitiveCell::Point2(point_b.clone()))
-            .unwrap();
+        let point_a = sketch.add_point2(1.0, 0.0).unwrap();
+        let point_b = sketch.add_point2(0.0, 1.0).unwrap();
 
         let constr1 = Rc::new(RefCell::new(HorizontalDistanceBetweenPoints::new(
             point_a.clone(),

--- a/src/constraints/fix_point.rs
+++ b/src/constraints/fix_point.rs
@@ -77,7 +77,6 @@ mod tests {
 
     use crate::{
         constraints::{fix_point::FixPoint, ConstraintCell, ConstraintLike},
-        primitives::{point2::Point2, PrimitiveCell},
         sketch::Sketch,
         solvers::{gradient_based_solver::GradientBasedSolver, Solver},
     };
@@ -86,10 +85,7 @@ mod tests {
     fn test_fix_point() {
         let mut sketch = Sketch::new();
 
-        let point = Rc::new(RefCell::new(Point2::new(1.0, 0.0)));
-        sketch
-            .add_primitive(PrimitiveCell::Point2(point.clone()))
-            .unwrap();
+        let point = sketch.add_point2(1.0, 0.0).unwrap();
 
         let constr1 = Rc::new(RefCell::new(FixPoint::new(
             point.clone(),

--- a/src/examples/test_rectangle_rotated.rs
+++ b/src/examples/test_rectangle_rotated.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 pub struct RotatedRectangleDemo {
-    pub sketch: Rc<RefCell<Sketch>>,
+    pub sketch: Sketch,
     pub point_a: Rc<RefCell<Point2>>,
     pub point_b: Rc<RefCell<Point2>>,
     pub point_c: Rc<RefCell<Point2>>,
@@ -30,7 +30,7 @@ impl Default for RotatedRectangleDemo {
 
 impl RotatedRectangleDemo {
     pub fn new() -> Self {
-        let sketch = Rc::new(RefCell::new(Sketch::new()));
+        let mut sketch = Sketch::new();
 
         // This time we have to choose some random start points to break the symmetry
         let point_a = Rc::new(RefCell::new(Point2::new(0.0, 0.1)));
@@ -41,23 +41,18 @@ impl RotatedRectangleDemo {
         let point_reference = Rc::new(RefCell::new(Point2::new(1.0, 0.0)));
 
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_a.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_b.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_c.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_d.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Point2(point_reference.clone()))
             .unwrap();
 
@@ -67,25 +62,20 @@ impl RotatedRectangleDemo {
         let line_d = Rc::new(RefCell::new(Line::new(point_d.clone(), point_a.clone())));
 
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line_a.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line_b.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line_c.clone()))
             .unwrap();
         sketch
-            .borrow_mut()
             .add_primitive(PrimitiveCell::Line(line_d.clone()))
             .unwrap();
 
         // Fix point a to origin
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::FixPoint(Rc::new(RefCell::new(
                 FixPoint::new(point_a.clone(), Vector2::new(0.0, 0.0)),
             ))))
@@ -93,7 +83,6 @@ impl RotatedRectangleDemo {
 
         // Constrain line_a and line_b to be perpendicular
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::PerpendicularLines(Rc::new(RefCell::new(
                 PerpendicularLines::new(line_a.clone(), line_b.clone()),
             ))))
@@ -101,7 +90,6 @@ impl RotatedRectangleDemo {
 
         // Constrain line_b and line_c to be perpendicular
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::PerpendicularLines(Rc::new(RefCell::new(
                 PerpendicularLines::new(line_b.clone(), line_c.clone()),
             ))))
@@ -109,7 +97,6 @@ impl RotatedRectangleDemo {
 
         // Constrain line_c and line_d to be perpendicular
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::PerpendicularLines(Rc::new(RefCell::new(
                 PerpendicularLines::new(line_c.clone(), line_d.clone()),
             ))))
@@ -123,7 +110,6 @@ impl RotatedRectangleDemo {
 
         // Constrain the length of line_a to 2
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::EuclideanDistance(Rc::new(RefCell::new(
                 EuclidianDistanceBetweenPoints::new(point_a.clone(), point_b.clone(), 2.0),
             ))))
@@ -131,7 +117,6 @@ impl RotatedRectangleDemo {
 
         // Constrain the length of line_b to 3
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::EuclideanDistance(Rc::new(RefCell::new(
                 EuclidianDistanceBetweenPoints::new(point_a.clone(), point_d.clone(), 3.0),
             ))))
@@ -139,7 +124,6 @@ impl RotatedRectangleDemo {
 
         // Fix reference point
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::FixPoint(Rc::new(RefCell::new(
                 FixPoint::new(point_reference.clone(), Vector2::new(1.0, 0.0)),
             ))))
@@ -147,7 +131,6 @@ impl RotatedRectangleDemo {
 
         // Constrain rotation of line_a to 45 degrees
         sketch
-            .borrow_mut()
             .add_constraint(ConstraintCell::AngleBetweenPoints(Rc::new(RefCell::new(
                 AngleBetweenPoints::new(
                     point_reference.clone(),
@@ -253,13 +236,11 @@ mod tests {
 
     #[test]
     pub fn test_rectangle_rotated() -> Result<(), Box<dyn Error>> {
-        let rectangle = RotatedRectangleDemo::new();
+        let mut rectangle = RotatedRectangleDemo::new();
 
         // Now solve the sketch
         let solver = BFGSSolver::new();
-        solver
-            .solve(rectangle.sketch.borrow_mut().deref_mut())
-            .unwrap();
+        solver.solve(&mut rectangle.sketch).unwrap();
 
         println!("point_a: {:?}", rectangle.point_a.as_ref().borrow());
         println!("point_b: {:?}", rectangle.point_b.as_ref().borrow());

--- a/src/examples/test_rectangle_rotated.rs
+++ b/src/examples/test_rectangle_rotated.rs
@@ -4,15 +4,7 @@ use std::{cell::RefCell, rc::Rc};
 use nalgebra::Vector2;
 
 use crate::error::ISOTopeError;
-use crate::{
-    constraints::{
-        angle_between_points::AngleBetweenPoints,
-        distance::euclidian_distance_between_points::EuclidianDistanceBetweenPoints,
-        fix_point::FixPoint, lines::perpendicular_lines::PerpendicularLines, ConstraintCell,
-    },
-    primitives::point2::Point2,
-    sketch::Sketch,
-};
+use crate::{primitives::point2::Point2, sketch::Sketch};
 
 pub struct RotatedRectangleDemo {
     pub sketch: Sketch,
@@ -47,32 +39,14 @@ impl RotatedRectangleDemo {
         let line_d = sketch.add_line(point_d.clone(), point_a.clone())?;
 
         // Fix point a to origin
-        sketch
-            .add_constraint(ConstraintCell::FixPoint(Rc::new(RefCell::new(
-                FixPoint::new(point_a.clone(), Vector2::new(0.0, 0.0)),
-            ))))
-            .unwrap();
+        sketch.constrain_fix_point(point_a.clone(), Vector2::new(0.0, 0.0))?;
 
         // Constrain line_a and line_b to be perpendicular
-        sketch
-            .add_constraint(ConstraintCell::PerpendicularLines(Rc::new(RefCell::new(
-                PerpendicularLines::new(line_a.clone(), line_b.clone()),
-            ))))
-            .unwrap();
+        sketch.constrain_perpendicular_lines(line_a, line_b.clone())?;
 
         // Constrain line_b and line_c to be perpendicular
-        sketch
-            .add_constraint(ConstraintCell::PerpendicularLines(Rc::new(RefCell::new(
-                PerpendicularLines::new(line_b.clone(), line_c.clone()),
-            ))))
-            .unwrap();
-
-        // Constrain line_c and line_d to be perpendicular
-        sketch
-            .add_constraint(ConstraintCell::PerpendicularLines(Rc::new(RefCell::new(
-                PerpendicularLines::new(line_c.clone(), line_d.clone()),
-            ))))
-            .unwrap();
+        sketch.constrain_perpendicular_lines(line_b, line_c.clone())?;
+        sketch.constrain_perpendicular_lines(line_c, line_d)?;
 
         // // Constrain line_d and line_a to be perpendicular
         // sketch.borrow_mut().add_constraint(Rc::new(RefCell::new(PerpendicularLines::new(
@@ -81,37 +55,21 @@ impl RotatedRectangleDemo {
         // ))));
 
         // Constrain the length of line_a to 2
-        sketch
-            .add_constraint(ConstraintCell::EuclideanDistance(Rc::new(RefCell::new(
-                EuclidianDistanceBetweenPoints::new(point_a.clone(), point_b.clone(), 2.0),
-            ))))
-            .unwrap();
+        sketch.constrain_distance_euclidean(point_a.clone(), point_b.clone(), 2.0)?;
 
         // Constrain the length of line_b to 3
-        sketch
-            .add_constraint(ConstraintCell::EuclideanDistance(Rc::new(RefCell::new(
-                EuclidianDistanceBetweenPoints::new(point_a.clone(), point_d.clone(), 3.0),
-            ))))
-            .unwrap();
+        sketch.constrain_distance_euclidean(point_a.clone(), point_d.clone(), 3.0)?;
 
         // Fix reference point
-        sketch
-            .add_constraint(ConstraintCell::FixPoint(Rc::new(RefCell::new(
-                FixPoint::new(point_reference.clone(), Vector2::new(1.0, 0.0)),
-            ))))
-            .unwrap();
+        sketch.constrain_fix_point(point_reference.clone(), Vector2::new(1.0, 0.0))?;
 
         // Constrain rotation of line_a to 45 degrees
-        sketch
-            .add_constraint(ConstraintCell::AngleBetweenPoints(Rc::new(RefCell::new(
-                AngleBetweenPoints::new(
-                    point_reference.clone(),
-                    point_b.clone(),
-                    point_a.clone(),
-                    f64::to_radians(45.0),
-                ),
-            ))))
-            .unwrap();
+        sketch.constrain_angle_between_points(
+            point_reference.clone(),
+            point_b.clone(),
+            point_a.clone(),
+            f64::to_radians(45.0),
+        )?;
 
         Ok(Self {
             sketch,

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -9,6 +9,8 @@ use crate::constraints::ConstraintCell;
 use crate::decompose::face::Face;
 use crate::decompose::{decompose_sketch, merge_faces};
 use crate::error::ISOTopeError;
+use crate::primitives::line::Line;
+use crate::primitives::point2::Point2;
 use crate::primitives::{point2, PrimitiveCell};
 
 use super::constraints::ConstraintLike;
@@ -41,6 +43,22 @@ impl Sketch {
         self.primitives_next_id += 1;
 
         Ok(self.primitives_next_id - 1)
+    }
+
+    pub fn add_point2(&mut self, x: f64, y: f64) -> Result<Rc<RefCell<Point2>>, ISOTopeError> {
+        let point = Rc::new(RefCell::new(Point2::new(x, y)));
+        self.add_primitive(PrimitiveCell::Point2(point.clone()))?;
+        Ok(point)
+    }
+
+    pub fn add_line(
+        &mut self,
+        start: Rc<RefCell<Point2>>,
+        end: Rc<RefCell<Point2>>,
+    ) -> Result<Rc<RefCell<Line>>, ISOTopeError> {
+        let line = Rc::new(RefCell::new(Line::new(start, end)));
+        self.add_primitive(PrimitiveCell::Line(line.clone()))?;
+        Ok(line)
     }
 
     pub fn get_num_primitives(&self) -> usize {
@@ -356,7 +374,7 @@ mod tests {
 
     #[test]
     fn test_data_and_grad_functions() {
-        let rect = RotatedRectangleDemo::new();
+        let rect = RotatedRectangleDemo::new().unwrap();
         let mut sketch = rect.sketch;
         sketch.get_data();
         sketch.get_loss();

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -2,9 +2,14 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
 use std::rc::Rc;
 
-use nalgebra::{DMatrix, DVector};
+use nalgebra::{DMatrix, DVector, Vector2};
 use serde::{Deserialize, Serialize};
 
+use crate::constraints::angle_between_points::AngleBetweenPoints;
+use crate::constraints::distance::euclidian_distance_between_points::EuclidianDistanceBetweenPoints;
+use crate::constraints::fix_point::FixPoint;
+use crate::constraints::lines::parallel_lines::ParallelLines;
+use crate::constraints::lines::perpendicular_lines::PerpendicularLines;
 use crate::constraints::ConstraintCell;
 use crate::decompose::face::Face;
 use crate::decompose::{decompose_sketch, merge_faces};
@@ -79,6 +84,70 @@ impl Sketch {
         )));
         self.add_primitive(PrimitiveCell::Arc(arc.clone()))?;
         Ok(arc)
+    }
+
+    pub fn constrain_perpendicular_lines(
+        &mut self,
+        line1: Rc<RefCell<Line>>,
+        line2: Rc<RefCell<Line>>,
+    ) -> Result<Rc<RefCell<PerpendicularLines>>, ISOTopeError> {
+        let perpendicular_lines = Rc::new(RefCell::new(PerpendicularLines::new(line1, line2)));
+        self.add_constraint(ConstraintCell::PerpendicularLines(
+            perpendicular_lines.clone(),
+        ))?;
+        Ok(perpendicular_lines)
+    }
+
+    pub fn constrain_parallel_lines(
+        &mut self,
+        line1: Rc<RefCell<Line>>,
+        line2: Rc<RefCell<Line>>,
+    ) -> Result<Rc<RefCell<ParallelLines>>, ISOTopeError> {
+        let parallel_lines = Rc::new(RefCell::new(ParallelLines::new(line1, line2)));
+        self.add_constraint(ConstraintCell::ParallelLines(parallel_lines.clone()))?;
+        Ok(parallel_lines)
+    }
+
+    pub fn constrain_distance_euclidean(
+        &mut self,
+        point1: Rc<RefCell<Point2>>,
+        point2: Rc<RefCell<Point2>>,
+        desired_distance: f64,
+    ) -> Result<Rc<RefCell<EuclidianDistanceBetweenPoints>>, ISOTopeError> {
+        let distance = Rc::new(RefCell::new(EuclidianDistanceBetweenPoints::new(
+            point1,
+            point2,
+            desired_distance,
+        )));
+        self.add_constraint(ConstraintCell::EuclideanDistance(distance.clone()))?;
+        Ok(distance)
+    }
+
+    pub fn constrain_fix_point(
+        &mut self,
+        point: Rc<RefCell<Point2>>,
+        desired_pos: Vector2<f64>,
+    ) -> Result<Rc<RefCell<FixPoint>>, ISOTopeError> {
+        let fix_point = Rc::new(RefCell::new(FixPoint::new(point, desired_pos)));
+        self.add_constraint(ConstraintCell::FixPoint(fix_point.clone()))?;
+        Ok(fix_point)
+    }
+
+    pub fn constrain_angle_between_points(
+        &mut self,
+        point1: Rc<RefCell<Point2>>,
+        point2: Rc<RefCell<Point2>>,
+        middle_point: Rc<RefCell<Point2>>,
+        desired_angle: f64,
+    ) -> Result<Rc<RefCell<AngleBetweenPoints>>, ISOTopeError> {
+        let angle = Rc::new(RefCell::new(AngleBetweenPoints::new(
+            point1,
+            point2,
+            middle_point,
+            desired_angle,
+        )));
+        self.add_constraint(ConstraintCell::AngleBetweenPoints(angle.clone()))?;
+        Ok(angle)
     }
 
     pub fn get_num_primitives(&self) -> usize {
@@ -368,15 +437,8 @@ mod tests {
         assert!(std::panic::catch_unwind(|| {
             let mut sketch = Sketch::new();
 
-            let point = Rc::new(RefCell::new(Point2::new(0.0, 0.0)));
-            let arc = Rc::new(RefCell::new(Arc::new(point.clone(), 1.0, true, 0.0, 1.0)));
-
-            sketch
-                .add_primitive(PrimitiveCell::Point2(point.clone()))
-                .unwrap();
-            sketch
-                .add_primitive(PrimitiveCell::Arc(arc.clone()))
-                .unwrap();
+            let point = sketch.add_point2(0.0, 0.0).unwrap();
+            let arc = sketch.add_arc(point.clone(), 1.0, true, 0.0, 1.0).unwrap();
 
             let constraint = Rc::new(RefCell::new(ArcEndPointCoincident::new(
                 arc.clone(),

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -9,6 +9,7 @@ use crate::constraints::ConstraintCell;
 use crate::decompose::face::Face;
 use crate::decompose::{decompose_sketch, merge_faces};
 use crate::error::ISOTopeError;
+use crate::primitives::arc::Arc;
 use crate::primitives::line::Line;
 use crate::primitives::point2::Point2;
 use crate::primitives::{point2, PrimitiveCell};
@@ -59,6 +60,25 @@ impl Sketch {
         let line = Rc::new(RefCell::new(Line::new(start, end)));
         self.add_primitive(PrimitiveCell::Line(line.clone()))?;
         Ok(line)
+    }
+
+    pub fn add_arc(
+        &mut self,
+        center: Rc<RefCell<Point2>>,
+        radius: f64,
+        clockwise: bool,
+        start_angle: f64,
+        end_angle: f64,
+    ) -> Result<Rc<RefCell<Arc>>, ISOTopeError> {
+        let arc = Rc::new(RefCell::new(Arc::new(
+            center,
+            radius,
+            clockwise,
+            start_angle,
+            end_angle,
+        )));
+        self.add_primitive(PrimitiveCell::Arc(arc.clone()))?;
+        Ok(arc)
     }
 
     pub fn get_num_primitives(&self) -> usize {

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -357,7 +357,7 @@ mod tests {
     #[test]
     fn test_data_and_grad_functions() {
         let rect = RotatedRectangleDemo::new();
-        let mut sketch = rect.sketch.borrow_mut();
+        let mut sketch = rect.sketch;
         sketch.get_data();
         sketch.get_loss();
         sketch.get_gradient();

--- a/src/solvers/bfgs_solver.rs
+++ b/src/solvers/bfgs_solver.rs
@@ -122,7 +122,6 @@ impl Solver for BFGSSolver {
 #[cfg(test)]
 mod tests {
     use std::error::Error;
-    use std::ops::DerefMut;
 
     use crate::{
         examples::test_rectangle_rotated::RotatedRectangleDemo,
@@ -131,7 +130,7 @@ mod tests {
 
     #[test]
     pub fn test_bfgs_solver() -> Result<(), Box<dyn Error>> {
-        let mut rectangle = RotatedRectangleDemo::new();
+        let mut rectangle = RotatedRectangleDemo::new()?;
 
         // Now solve the sketch
         let solver = BFGSSolver::new();

--- a/src/solvers/bfgs_solver.rs
+++ b/src/solvers/bfgs_solver.rs
@@ -131,15 +131,13 @@ mod tests {
 
     #[test]
     pub fn test_bfgs_solver() -> Result<(), Box<dyn Error>> {
-        let rectangle = RotatedRectangleDemo::new();
+        let mut rectangle = RotatedRectangleDemo::new();
 
         // Now solve the sketch
         let solver = BFGSSolver::new();
-        solver
-            .solve(rectangle.sketch.borrow_mut().deref_mut())
-            .unwrap();
+        solver.solve(&mut rectangle.sketch).unwrap();
 
-        println!("loss: {:?}", rectangle.sketch.borrow_mut().get_loss());
+        println!("loss: {:?}", rectangle.sketch.get_loss());
         println!("point_a: {:?}", rectangle.point_a.as_ref().borrow());
         println!("point_b: {:?}", rectangle.point_b.as_ref().borrow());
         println!("point_c: {:?}", rectangle.point_c.as_ref().borrow());

--- a/src/solvers/gauss_newton_solver.rs
+++ b/src/solvers/gauss_newton_solver.rs
@@ -66,7 +66,6 @@ impl Solver for GaussNewtonSolver {
 #[cfg(test)]
 mod tests {
     use std::error::Error;
-    use std::ops::DerefMut;
 
     use crate::{
         examples::test_rectangle_rotated::RotatedRectangleDemo,
@@ -75,15 +74,13 @@ mod tests {
 
     #[test]
     pub fn test_gauss_newton_solver() -> Result<(), Box<dyn Error>> {
-        let rectangle = RotatedRectangleDemo::new();
+        let mut rectangle = RotatedRectangleDemo::new();
 
         // Now solve the sketch
         let solver = GaussNewtonSolver::new_with_params(500, 1e-8, 1e0);
-        solver
-            .solve(rectangle.sketch.borrow_mut().deref_mut())
-            .unwrap();
+        solver.solve(&mut rectangle.sketch).unwrap();
 
-        println!("loss: {:?}", rectangle.sketch.borrow_mut().get_loss());
+        println!("loss: {:?}", rectangle.sketch.get_loss());
         println!("point_a: {:?}", rectangle.point_a.as_ref());
         println!("point_b: {:?}", rectangle.point_b.as_ref());
         println!("point_c: {:?}", rectangle.point_c.as_ref());

--- a/src/solvers/gauss_newton_solver.rs
+++ b/src/solvers/gauss_newton_solver.rs
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     pub fn test_gauss_newton_solver() -> Result<(), Box<dyn Error>> {
-        let mut rectangle = RotatedRectangleDemo::new();
+        let mut rectangle = RotatedRectangleDemo::new()?;
 
         // Now solve the sketch
         let solver = GaussNewtonSolver::new_with_params(500, 1e-8, 1e0);

--- a/src/solvers/levenberg_marquardt.rs
+++ b/src/solvers/levenberg_marquardt.rs
@@ -85,7 +85,7 @@ mod tests {
 
     #[test]
     pub fn test_levenberg_marquardt_solver() -> Result<(), Box<dyn Error>> {
-        let mut rectangle = RotatedRectangleDemo::new();
+        let mut rectangle = RotatedRectangleDemo::new()?;
 
         // Now solve the sketch
         let solver = LevenbergMarquardtSolver::new_with_params(1000, 1e-10, 1e-1, 1e-5);

--- a/src/solvers/levenberg_marquardt.rs
+++ b/src/solvers/levenberg_marquardt.rs
@@ -77,7 +77,6 @@ impl Solver for LevenbergMarquardtSolver {
 #[cfg(test)]
 mod tests {
     use std::error::Error;
-    use std::ops::DerefMut;
 
     use crate::{
         examples::test_rectangle_rotated::RotatedRectangleDemo,
@@ -86,15 +85,13 @@ mod tests {
 
     #[test]
     pub fn test_levenberg_marquardt_solver() -> Result<(), Box<dyn Error>> {
-        let rectangle = RotatedRectangleDemo::new();
+        let mut rectangle = RotatedRectangleDemo::new();
 
         // Now solve the sketch
         let solver = LevenbergMarquardtSolver::new_with_params(1000, 1e-10, 1e-1, 1e-5);
-        solver
-            .solve(rectangle.sketch.borrow_mut().deref_mut())
-            .unwrap();
+        solver.solve(&mut rectangle.sketch).unwrap();
 
-        println!("loss: {:?}", rectangle.sketch.borrow_mut().get_loss());
+        println!("loss: {:?}", rectangle.sketch.get_loss());
         println!("point_a: {:?}", rectangle.point_a.as_ref());
         println!("point_b: {:?}", rectangle.point_b.as_ref());
         println!("point_c: {:?}", rectangle.point_c.as_ref());


### PR DESCRIPTION
This PR adds functions to sketch add_point, add_line and constrain_* functions to sketch, to make the developer experience nicer and less verbose, by hiding the Rc<Refcell<>> construction.
Here's how it compares to the previous API:
OLD:
```rust
impl RotatedRectangleDemo {
    pub fn new() -> Self {
        let sketch = Rc::new(RefCell::new(Sketch::new()));

        // This time we have to choose some random start points to break the symmetry
        let point_a = Rc::new(RefCell::new(Point2::new(0.0, 0.1)));
        let point_b = Rc::new(RefCell::new(Point2::new(0.3, 0.0)));
        let point_c = Rc::new(RefCell::new(Point2::new(0.3, 0.3)));
        let point_d = Rc::new(RefCell::new(Point2::new(0.1, 0.3)));

        let point_reference = Rc::new(RefCell::new(Point2::new(1.0, 0.0)));

        sketch
            .borrow_mut()
            .add_primitive(PrimitiveCell::Point2(point_a.clone()))
            .unwrap();
        sketch
            .borrow_mut()
            .add_primitive(PrimitiveCell::Point2(point_b.clone()))
            .unwrap();
        sketch
            .borrow_mut()
            .add_primitive(PrimitiveCell::Point2(point_c.clone()))
            .unwrap();
        sketch
            .borrow_mut()
            .add_primitive(PrimitiveCell::Point2(point_d.clone()))
            .unwrap();
        sketch
            .borrow_mut()
            .add_primitive(PrimitiveCell::Point2(point_reference.clone()))
            .unwrap();

        let line_a = Rc::new(RefCell::new(Line::new(point_a.clone(), point_b.clone())));
        let line_b = Rc::new(RefCell::new(Line::new(point_b.clone(), point_c.clone())));
        let line_c = Rc::new(RefCell::new(Line::new(point_c.clone(), point_d.clone())));
        let line_d = Rc::new(RefCell::new(Line::new(point_d.clone(), point_a.clone())));

        sketch
            .borrow_mut()
            .add_primitive(PrimitiveCell::Line(line_a.clone()))
            .unwrap();
        sketch
            .borrow_mut()
            .add_primitive(PrimitiveCell::Line(line_b.clone()))
            .unwrap();
        sketch
            .borrow_mut()
            .add_primitive(PrimitiveCell::Line(line_c.clone()))
            .unwrap();
        sketch
            .borrow_mut()
            .add_primitive(PrimitiveCell::Line(line_d.clone()))
            .unwrap();

        // Fix point a to origin
        sketch
            .borrow_mut()
            .add_constraint(ConstraintCell::FixPoint(Rc::new(RefCell::new(
                FixPoint::new(point_a.clone(), Vector2::new(0.0, 0.0)),
            ))))
            .unwrap();

        // Constrain line_a and line_b to be perpendicular
        sketch
            .borrow_mut()
            .add_constraint(ConstraintCell::PerpendicularLines(Rc::new(RefCell::new(
                PerpendicularLines::new(line_a.clone(), line_b.clone()),
            ))))
            .unwrap();

        // Constrain line_b and line_c to be perpendicular
        sketch
            .borrow_mut()
            .add_constraint(ConstraintCell::PerpendicularLines(Rc::new(RefCell::new(
                PerpendicularLines::new(line_b.clone(), line_c.clone()),
            ))))
            .unwrap();

        // Constrain line_c and line_d to be perpendicular
        sketch
            .borrow_mut()
            .add_constraint(ConstraintCell::PerpendicularLines(Rc::new(RefCell::new(
                PerpendicularLines::new(line_c.clone(), line_d.clone()),
            ))))
            .unwrap();

        // // Constrain line_d and line_a to be perpendicular
        // sketch.borrow_mut().add_constraint(Rc::new(RefCell::new(PerpendicularLines::new(
        //     line_d.clone(),
        //     line_a.clone(),
        // ))));

        // Constrain the length of line_a to 2
        sketch
            .borrow_mut()
            .add_constraint(ConstraintCell::EuclideanDistance(Rc::new(RefCell::new(
                EuclidianDistanceBetweenPoints::new(point_a.clone(), point_b.clone(), 2.0),
            ))))
            .unwrap();

        // Constrain the length of line_b to 3
        sketch
            .borrow_mut()
            .add_constraint(ConstraintCell::EuclideanDistance(Rc::new(RefCell::new(
                EuclidianDistanceBetweenPoints::new(point_a.clone(), point_d.clone(), 3.0),
            ))))
            .unwrap();

        // Fix reference point
        sketch
            .borrow_mut()
            .add_constraint(ConstraintCell::FixPoint(Rc::new(RefCell::new(
                FixPoint::new(point_reference.clone(), Vector2::new(1.0, 0.0)),
            ))))
            .unwrap();

        // Constrain rotation of line_a to 45 degrees
        sketch
            .borrow_mut()
            .add_constraint(ConstraintCell::AngleBetweenPoints(Rc::new(RefCell::new(
                AngleBetweenPoints::new(
                    point_reference.clone(),
                    point_b.clone(),
                    point_a.clone(),
                    f64::to_radians(45.0),
                ),
            ))))
            .unwrap();

        Self {
            sketch,
            point_a,
            point_b,
            point_c,
            point_d,
            point_reference,
        }
    }
```
    
with PR: 

```rust
pub fn new() -> Result<RotatedRectangleDemo, ISOTopeError> {
        let mut sketch = Sketch::new();

        // This time we have to choose some random start points to break the symmetry
        let point_a = sketch.add_point2(0.0, 0.1)?;
        let point_b = sketch.add_point2(0.3, 0.0)?;
        let point_c = sketch.add_point2(0.3, 0.3)?;
        let point_d = sketch.add_point2(0.1, 0.3)?;

        let point_reference = sketch.add_point2(1.0, 0.0)?;

        let line_a = sketch.add_line(point_a.clone(), point_b.clone())?;
        let line_b = sketch.add_line(point_b.clone(), point_c.clone())?;
        let line_c = sketch.add_line(point_c.clone(), point_d.clone())?;
        let line_d = sketch.add_line(point_d.clone(), point_a.clone())?;

        // Fix point a to origin
        sketch.constrain_fix_point(point_a.clone(), Vector2::new(0.0, 0.0))?;

        // Constrain line_a and line_b to be perpendicular
        sketch.constrain_perpendicular_lines(line_a, line_b.clone())?;

        // Constrain line_b and line_c to be perpendicular
        sketch.constrain_perpendicular_lines(line_b, line_c.clone())?;
        sketch.constrain_perpendicular_lines(line_c, line_d)?;

        // // Constrain line_d and line_a to be perpendicular
        // sketch.borrow_mut().add_constraint(Rc::new(RefCell::new(PerpendicularLines::new(
        //     line_d.clone(),
        //     line_a.clone(),
        // ))));

        // Constrain the length of line_a to 2
        sketch.constrain_distance_euclidean(point_a.clone(), point_b.clone(), 2.0)?;

        // Constrain the length of line_b to 3
        sketch.constrain_distance_euclidean(point_a.clone(), point_d.clone(), 3.0)?;

        // Fix reference point
        sketch.constrain_fix_point(point_reference.clone(), Vector2::new(1.0, 0.0))?;

        // Constrain rotation of line_a to 45 degrees
        sketch.constrain_angle_between_points(
            point_reference.clone(),
            point_b.clone(),
            point_a.clone(),
            f64::to_radians(45.0),
        )?;

        Ok(Self {
            sketch,
            point_a,
            point_b,
            point_c,
            point_d,
            point_reference,
        })
    }```
    
    
